### PR TITLE
Prevent hard crash when a feature is unsupported by AC

### DIFF
--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -401,26 +401,52 @@ bool HlinkAc::handle_hlink_request_response_(const HlinkRequest &request, const 
 void HlinkAc::publish_updates_if_any_() {
   if (this->hlink_entity_status_.has_hvac_status()) {
     bool should_publish_climate_state = false;
-    if (!is_nanable_equal_(this->target_temperature, this->hlink_entity_status_.target_temperature.value())) {
-      this->target_temperature = this->hlink_entity_status_.target_temperature.value();
-      should_publish_climate_state = true;
+    // Check Target Temp
+    if (this->hlink_entity_status_.target_temperature.has_value()) {
+      if (!is_nanable_equal_(this->target_temperature, this->hlink_entity_status_.target_temperature.value())) {
+        this->target_temperature = this->hlink_entity_status_.target_temperature.value();
+        should_publish_climate_state = true;
+      }
+    } else {
+      ESP_LOGW(TAG, "Target Temperature not reported by AC. Your model may not support this feature.");
     }
-    if (this->current_temperature != this->hlink_entity_status_.current_temperature.value()) {
-      this->current_temperature = this->hlink_entity_status_.current_temperature.value();
-      should_publish_climate_state = true;
+    // Check Current Temp
+    if (this->hlink_entity_status_.current_temperature.has_value()) {
+      if (this->current_temperature != this->hlink_entity_status_.current_temperature.value()) {
+        this->current_temperature = this->hlink_entity_status_.current_temperature.value();
+        should_publish_climate_state = true;
+      }
+    } else {
+      ESP_LOGW(TAG, "Current Temperature not reported by AC. Your model may not support this feature.");
     }
-    if (this->mode != this->hlink_entity_status_.mode) {
-      this->mode = this->hlink_entity_status_.mode.value();
-      should_publish_climate_state = true;
+    // Check Mode
+    if (this->hlink_entity_status_.mode.has_value()) {
+      if (this->mode != this->hlink_entity_status_.mode.value()) {
+        this->mode = this->hlink_entity_status_.mode.value();
+        should_publish_climate_state = true;
+      }
+    } else {
+      ESP_LOGW(TAG, "Mode not reported by AC. Your model may not support this feature.");
     }
-    if (this->fan_mode != this->hlink_entity_status_.fan_mode.value()) {
-      this->fan_mode = this->hlink_entity_status_.fan_mode.value();
-      should_publish_climate_state = true;
+    // Check Fan Mode (The specific line that crashed your ESP32)
+    if (this->hlink_entity_status_.fan_mode.has_value()) {
+      if (this->fan_mode != this->hlink_entity_status_.fan_mode.value()) {
+        this->fan_mode = this->hlink_entity_status_.fan_mode.value();
+        should_publish_climate_state = true;
+      }
+    } else {
+      ESP_LOGW(TAG, "Fan Mode not reported by AC. Your model may not support this feature.");
     }
-    if (this->swing_mode != this->hlink_entity_status_.swing_mode.value()) {
-      this->swing_mode = this->hlink_entity_status_.swing_mode.value();
-      should_publish_climate_state = true;
+    // Check Swing Mode
+    if (this->hlink_entity_status_.swing_mode.has_value()) {
+      if (this->swing_mode != this->hlink_entity_status_.swing_mode.value()) {
+        this->swing_mode = this->hlink_entity_status_.swing_mode.value();
+        should_publish_climate_state = true;
+      }
+    } else {
+      ESP_LOGW(TAG, "Swing Mode not reported by AC. Your model may not support this feature.");
     }
+
     if (this->hlink_entity_status_.action.has_value()) {
       if (this->hlink_entity_status_.action.value() != this->action) {
         this->action = this->hlink_entity_status_.action.value();
@@ -429,8 +455,9 @@ void HlinkAc::publish_updates_if_any_() {
     }
     if (this->hlink_entity_status_.leave_home_enabled.has_value()) {
       esphome::climate::ClimatePreset climate_preset = esphome::climate::ClimatePreset::CLIMATE_PRESET_NONE;
-      if (this->hlink_entity_status_.leave_home_enabled.value() && this->hlink_entity_status_.power_state.value() &&
-          this->hlink_entity_status_.target_temperature == 10) {
+      if (this->hlink_entity_status_.leave_home_enabled.value() && 
+          this->hlink_entity_status_.power_state.value_or(false) &&
+          this->hlink_entity_status_.target_temperature.value_or(0) == 10) {
         climate_preset = esphome::climate::ClimatePreset::CLIMATE_PRESET_AWAY;
       }
       if (this->preset != climate_preset) {


### PR DESCRIPTION
Just a warning before I begin: I'm not a coder. I asked an LLM to aid me in fixing this; I wrote the code myself but with the guidance of AI.

I was experiencing an ESP crash due to my (very old) AC not supporting vertical swing control. So, I wrapped relevant code in `publish_updates_if_any_` in `has_value` checks and return a warning in the log if not present, rather than crashing the ESP.

This has fixed the issue on [my setup](https://github.com/shardshunt/H-Link-Docks) that was causing the crash. An option would have been to adjust the YAML config; however, I feel the ESP crashing is not the ideal outcome, as wireless updates become impossible.

The behavior for the user now is that if the vertical swing is adjusted in Home Assistant, it will accept the change for a second until the AC updates its status, and then it will default back to off. I have also made the change for all the features in publish_updates_if_any_ in case of the edge case where another feature is unsupported or misbehaving.

Crash Text:
```
[E][esp32.crash:245]: BT3: 0x400D99AD (backtrace)
WARNING Decoded 0x400d99ad: std::__throw_bad_optional_access() at /cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/optional:107
(inlined by) std::optional<esphome::climate::ClimateFanMode>::value() & at /cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/optional:1001
(inlined by) esphome::hlink_ac::HlinkAc::publish_updates_if_any_() at /config/.esphome/build/hitachi-h-link-controller/src/esphome/components/hlink_ac/hlink_ac.cpp:416
```