### PR TITLE
Add indoor temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ switch:
 
 sensor:
   - platform: hlink_ac
+    indoor_temperature:
+      name: Indoor Temperature # Available when the climate reports room temperature
     outdoor_temperature:
       name: Outdoor Temperature # Available only when device is active
 
@@ -198,6 +200,7 @@ esphome:
     - Remote IR control lock
     - Beeper sounds
 3. Sensor
+    - Indoor temperature
     - Outdoor temperature
 4. Binary Sensor
     - Indoor unit air filter cleaning reminder

--- a/build/hlink_all.yml
+++ b/build/hlink_all.yml
@@ -32,6 +32,8 @@ climate:
 
 sensor:
   - platform: hlink_ac
+    indoor_temperature:
+      name: Indoor Temperature
     outdoor_temperature:
       name: Outdoor Temperature
 

--- a/build/hlink_all_arduino.yml
+++ b/build/hlink_all_arduino.yml
@@ -25,6 +25,8 @@ climate:
 
 sensor:
   - platform: hlink_ac
+    indoor_temperature:
+      name: Indoor Temperature
     outdoor_temperature:
       name: Outdoor Temperature
 

--- a/build/hlink_all_libretiny.yml
+++ b/build/hlink_all_libretiny.yml
@@ -32,6 +32,8 @@ climate:
 
 sensor:
   - platform: hlink_ac
+    indoor_temperature:
+      name: Indoor Temperature
     outdoor_temperature:
       name: Outdoor Temperature
 

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -89,6 +89,10 @@ HlinkAc::HlinkAc() {
   this->status_.polling_features.push_back(
       {{HlinkRequestFrame::Type::MT, {FeatureType::CURRENT_INDOOR_TEMP}}, [this](const HlinkResponseFrame &response) {
          this->hlink_entity_status_.current_temperature = response.p_value_as_uint16();
+#ifdef USE_SENSOR
+         this->update_sensor_state_(this->indoor_temperature_sensor_,
+                                    this->hlink_entity_status_.current_temperature.value_or(NAN));
+#endif
        }});
   this->status_.polling_features.push_back(
       {{HlinkRequestFrame::Type::MT, {FeatureType::FAN_MODE}}, [this](const HlinkResponseFrame &response) {
@@ -900,6 +904,13 @@ void HlinkAc::set_sensor(SensorType type, sensor::Sensor *s) {
                                                           : NAN;
                                                   this->update_sensor_state_(s, sensor_value);
                                                 }});
+      break;
+    case SensorType::INDOOR_TEMPERATURE:
+      this->indoor_temperature_sensor_ = s;
+      if (this->hlink_entity_status_.current_temperature.has_value()) {
+        this->update_sensor_state_(this->indoor_temperature_sensor_,
+                                   this->hlink_entity_status_.current_temperature.value());
+      }
       break;
     default:
       break;

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -251,7 +251,7 @@ enum class SensorType {
   OUTDOOR_TEMPERATURE = 0,
   INDOOR_TEMPERATURE = 1,
   // Used to count the number of sensors in the enum
-  COUNT = 2,
+  COUNT,
 };
 #endif
 #ifdef USE_BINARY_SENSOR

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -249,8 +249,9 @@ struct SendHlinkCmdResult {
 #ifdef USE_SENSOR
 enum class SensorType {
   OUTDOOR_TEMPERATURE = 0,
+  INDOOR_TEMPERATURE = 1,
   // Used to count the number of sensors in the enum
-  COUNT,
+  COUNT = 2,
 };
 #endif
 #ifdef USE_BINARY_SENSOR
@@ -306,6 +307,7 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
 
  protected:
   void update_sensor_state_(sensor::Sensor *sensor, float value);
+  sensor::Sensor *indoor_temperature_sensor_{nullptr};
 #endif
 #ifdef USE_BINARY_SENSOR
  public:

--- a/components/hlink_ac/sensor/__init__.py
+++ b/components/hlink_ac/sensor/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import (
     DEVICE_CLASS_TEMPERATURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_RADIATOR,
+    ICON_THERMOMETER,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
 )
@@ -18,8 +19,16 @@ CODEOWNERS = ["@lumixen"]
 SensorTypeEnum = hlink_ac_ns.enum("SensorType", True)
 
 OUTDOOR_TEMPERATURE = "outdoor_temperature"
+INDOOR_TEMPERATURE = "indoor_temperature"
 
 SENSOR_TYPES = {
+    INDOOR_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        icon=ICON_THERMOMETER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
     OUTDOOR_TEMPERATURE: sensor.sensor_schema(
         unit_of_measurement=UNIT_CELSIUS,
         icon=ICON_RADIATOR,


### PR DESCRIPTION
This PR adds support for the `indoor_temperature` sensor to the `hlink_ac` component.

The sensor reuses the AC unit’s reported current room temperature and exposes it as a standard Home Assistant temperature entity alongside the existing outdoor temperature sensor.

What’s included:
- New `sensor.hlink_ac.indoor_temperature` option
- ESPHome schema and codegen updates
- C++ wiring to publish the indoor temperature value
- README and example config updates

Result:

<img width="351" height="356" alt="Screenshot 2026-07-01 at 19 40 00" src="https://github.com/user-attachments/assets/6ead3cbf-e86f-4eab-beb7-eae3e9d947e8" />
