### PR TITLE
Remember target temperatures per mode and restore on turn-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ climate:
       - HORIZONTAL
       - BOTH
     reference_temperature: 25 # Optional. Center point (°C) for target temperature in HEAT_COOL (auto) mode. Settable range is ±3°C around this value. Defaults to 25.
-    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and restores it on boot when the AC is off.
+    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and writes it back when the AC is turned on from Home Assistant.
 
 switch:
   - platform: hlink_ac

--- a/README.md
+++ b/README.md
@@ -101,11 +101,7 @@ climate:
       - HORIZONTAL
       - BOTH
     reference_temperature: 25 # Optional. Center point (°C) for target temperature in HEAT_COOL (auto) mode. Settable range is ±3°C around this value. Defaults to 25.
-    initial_target_temperatures: # Optional. Sets target temperatures per mode on boot.
-      heat: 24
-      cool: 22
-      auto: 23
-      dry: 22
+    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and restores it on boot when the AC is off.
 
 switch:
   - platform: hlink_ac

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ climate:
       - HORIZONTAL
       - BOTH
     reference_temperature: 25 # Optional. Center point (°C) for target temperature in HEAT_COOL (auto) mode. Settable range is ±3°C around this value. Defaults to 25.
-    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and writes it back when the AC is turned on from Home Assistant.
+    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and writes it back when the AC is turned on or switched to a mode from Home Assistant.
 
 switch:
   - platform: hlink_ac

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ climate:
       - HORIZONTAL
       - BOTH
     reference_temperature: 25 # Optional. Center point (°C) for target temperature in HEAT_COOL (auto) mode. Settable range is ±3°C around this value. Defaults to 25.
-    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and writes it back when the AC is turned on or switched to a mode from Home Assistant.
+    remember_target_temperatures: false # Optional. Defaults to false. Remembers the last target temperature set by the user per mode and writes it back when the AC is turned on.
 
 switch:
   - platform: hlink_ac

--- a/build/hlink_all.yml
+++ b/build/hlink_all.yml
@@ -29,11 +29,7 @@ climate:
       - "BOTH"
     status_update_interval: 1000
     reference_temperature: 23
-    initial_target_temperatures:
-      cool: 22
-      heat: 24
-      auto: 20
-      dry: 22
+    remember_target_temperatures: true
 
 sensor:
   - platform: hlink_ac

--- a/build/hlink_all_arduino.yml
+++ b/build/hlink_all_arduino.yml
@@ -22,11 +22,6 @@ uart:
 climate:
   - platform: hlink_ac
     name: "H-Link Test Climate Device"
-    initial_target_temperatures:
-      cool: 22
-      heat: 24
-      auto: 23
-      dry: 22
 
 sensor:
   - platform: hlink_ac

--- a/build/hlink_all_libretiny.yml
+++ b/build/hlink_all_libretiny.yml
@@ -29,9 +29,6 @@ climate:
       - "VERTICAL"
       - "HORIZONTAL"
       - "BOTH"
-    initial_target_temperatures:
-      cool: 22
-      heat: 24
 
 sensor:
   - platform: hlink_ac

--- a/components/hlink_ac/climate.py
+++ b/components/hlink_ac/climate.py
@@ -2,7 +2,6 @@ from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, uart
-from esphome.codegen import StructInitializer
 from esphome.components.climate import (
     CONF_CURRENT_TEMPERATURE,
     ClimateMode,
@@ -33,20 +32,17 @@ hlink_ac_ns = cg.esphome_ns.namespace("hlink_ac")
 HlinkAc = hlink_ac_ns.class_("HlinkAc", cg.Component, uart.UARTDevice, climate.Climate)
 SendHlinkCmdResult = hlink_ac_ns.struct("SendHlinkCmdResult")
 SendHlinkCmdResultConstRef = SendHlinkCmdResult.operator("ref").operator("const")
-InitialTargetTemperatures = hlink_ac_ns.struct("InitialTargetTemperatures")
 
 CONF_HLINK_AC_ID = "hlink_ac_id"
 CONF_STATUS_UPDATE_INTERVAL = "status_update_interval"
 CONF_REFERENCE_TEMPERATURE = "reference_temperature"
-CONF_INITIAL_TARGET_TEMPERATURES = "initial_target_temperatures"
+CONF_REMEMBER_TARGET_TEMPERATURES = "remember_target_temperatures"
 CONF_ON_SEND_HLINK_CMD_RESULT = "on_send_hlink_cmd_result"
 
 PROTOCOL_MIN_TEMPERATURE = 16.0
 PROTOCOL_MAX_TEMPERATURE = 32.0
 PROTOCOL_TARGET_TEMPERATURE_STEP = 1.0
 PROTOCOL_CURRENT_TEMPERATURE_STEP = 1.0
-AUTO_MODE_TARGET_TEMPERATURE_DELTA_MIN = -3.0
-AUTO_MODE_TARGET_TEMPERATURE_DELTA_MAX = 3.0
 
 SUPPORT_HVAC_ACTIONS = "hvac_actions"
 
@@ -185,22 +181,6 @@ def validate_visual(config):
     return config
 
 
-def validate_initial_target_temperatures(config):
-    if CONF_INITIAL_TARGET_TEMPERATURES in config:
-        ref_temp = config.get(CONF_REFERENCE_TEMPERATURE, 25)
-        boot = config[CONF_INITIAL_TARGET_TEMPERATURES]
-        if "auto" in boot:
-            auto_temp = boot["auto"]
-            min_temp = ref_temp + AUTO_MODE_TARGET_TEMPERATURE_DELTA_MIN
-            max_temp = ref_temp + AUTO_MODE_TARGET_TEMPERATURE_DELTA_MAX
-            if auto_temp < min_temp or auto_temp > max_temp:
-                raise cv.Invalid(
-                    f"Auto temperature {auto_temp} must be within {min_temp}-{max_temp} "
-                    f"relative to reference_temperature ({ref_temp})"
-                )
-    return config
-
-
 CONFIG_SCHEMA = cv.All(
     climate.climate_schema(HlinkAc)
     .extend(
@@ -231,26 +211,13 @@ CONFIG_SCHEMA = cv.All(
                 default=25,
             ): cv.All(cv.int_, cv.Range(min=PROTOCOL_MIN_TEMPERATURE, max=PROTOCOL_MAX_TEMPERATURE)),
             cv.Optional(
+                CONF_REMEMBER_TARGET_TEMPERATURES,
+                default=False,
+            ): cv.boolean,
+            cv.Optional(
                 CONF_STATUS_UPDATE_INTERVAL,
                 default="5000",
             ): cv.All(cv.uint32_t, cv.Range(min=100, max=60000)),
-            cv.Optional(CONF_INITIAL_TARGET_TEMPERATURES): cv.Schema(
-                {
-                    cv.Optional("cool"): cv.All(
-                        cv.temperature,
-                        cv.Range(min=PROTOCOL_MIN_TEMPERATURE, max=PROTOCOL_MAX_TEMPERATURE),
-                    ),
-                    cv.Optional("heat"): cv.All(
-                        cv.temperature,
-                        cv.Range(min=PROTOCOL_MIN_TEMPERATURE, max=PROTOCOL_MAX_TEMPERATURE),
-                    ),
-                    cv.Optional("auto"): cv.temperature,
-                    cv.Optional("dry"): cv.All(
-                        cv.temperature,
-                        cv.Range(min=PROTOCOL_MIN_TEMPERATURE, max=PROTOCOL_MAX_TEMPERATURE),
-                    ),
-                }
-            ),
             cv.Optional(CONF_ON_SEND_HLINK_CMD_RESULT): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -263,7 +230,6 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
     validate_visual,
-    validate_initial_target_temperatures,
 )
 
 
@@ -275,20 +241,7 @@ async def to_code(config):
 
     cg.add(var.set_status_update_interval(config[CONF_STATUS_UPDATE_INTERVAL]))
     cg.add(var.set_reference_temperature(config[CONF_REFERENCE_TEMPERATURE]))
-
-    if CONF_INITIAL_TARGET_TEMPERATURES in config:
-        boot = config[CONF_INITIAL_TARGET_TEMPERATURES]
-        boot_init = []
-        if "heat" in boot:
-            boot_init.append(("heat_target_temperature", boot["heat"]))
-        if "cool" in boot:
-            boot_init.append(("cool_target_temperature", boot["cool"]))
-        if "auto" in boot:
-            boot_init.append(("heat_cool_target_temperature", boot["auto"]))
-        if "dry" in boot:
-            boot_init.append(("dry_target_temperature", boot["dry"]))
-        if boot_init:
-            cg.add(var.set_initial_target_temperatures(StructInitializer(InitialTargetTemperatures, *boot_init)))
+    cg.add(var.set_remember_target_temperatures(config[CONF_REMEMBER_TARGET_TEMPERATURES]))
 
     if CONF_SUPPORTED_MODES in config:
         cg.add(var.set_supported_climate_modes(config[CONF_SUPPORTED_MODES]))

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -12,102 +12,118 @@ const HlinkResponseFrame HLINK_RESPONSE_ACK_OK = {HlinkResponseFrame::Status::OK
 
 HlinkAc::HlinkAc() {
   // Setup default polling features, ordering is important
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::POWER_STATE}}, [this](const HlinkResponseFrame &response) {
-         auto power_state = response.p_value_as_uint16();
-         if (power_state.has_value()) {
-           this->hlink_entity_status_.power_state = static_cast<bool>(power_state.value());
-         } else {
-           this->hlink_entity_status_.power_state = {};
-         }
-       }});
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::MODE}}, [this](const HlinkResponseFrame &response) {
-         if (!this->hlink_entity_status_.power_state.has_value()) {
-           ESP_LOGW(TAG, "Can't handle climate mode response without power state data");
-           return;
-         }
-         this->hlink_entity_status_.hlink_climate_mode = response.p_value_as_uint16();
-         if (!this->hlink_entity_status_.power_state.value()) {
-           // Climate mode should be off when device is turned off
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_OFF;
-           return;
-         }
-         if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_COOL;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_DRY) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_DRY;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_FAN) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_FAN_ONLY;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT_AUTO) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL_AUTO) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_DRY_AUTO) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
-         } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_AUTO) {
-           this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
-         }
-       }});
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::TARGET_TEMP}}, [this](const HlinkResponseFrame &response) {
-         if (this->hlink_entity_status_.power_state.has_value() && !this->hlink_entity_status_.power_state.value()) {
-           this->hlink_entity_status_.target_temperature = NAN;
-           return;
-         }
-         if (response.p_value_as_uint16().has_value()) {
-           uint16_t target_temperature = response.p_value_as_uint16().value();
-           if (this->hlink_entity_status_.hlink_climate_mode.has_value() &&
-               this->is_auto_temperature_mode_(this->hlink_entity_status_.hlink_climate_mode.value()) &&
-               target_temperature >= 0xFF00) {
-             // In auto mode the target temperature control is not available
-             // Instead, AC expects temperature offset in range [-3;+3] C
-             // AUTO HEATING: FFFD -> FFFF, FFFE -> FF00, FFFF -> FF01, FF00 -> FF02, FF01 -> FF03, FF02 -> FF04, FF03
-             // -> FF05
-             // AUTO COOLING: FFFD -> FFFB, FFFE -> FFFC, FFFF -> FFFD, FF00 -> FFFE, FF01 -> FFFF, FF02 ->
-             // FF00, FF03 -> FF01
-             // Needs testing, it's not clear if offset makes any difference in real life
-             int8_t offset_temp = static_cast<int8_t>(target_temperature - 0xFF00);
-             int8_t adjusted_offset = offset_temp;
-             if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT_AUTO) {
-               adjusted_offset = offset_temp - 2;
-             } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL_AUTO) {
-               adjusted_offset = offset_temp + 2;
-             }
-             this->hlink_entity_status_.target_temperature =
-                 this->clamp_auto_temperature_(this->reference_temperature_ + adjusted_offset);
-           } else if (target_temperature >= PROTOCOL_TARGET_TEMP_MIN &&
-                      target_temperature <= PROTOCOL_TARGET_TEMP_MAX) {
-             this->hlink_entity_status_.target_temperature = target_temperature;
-           } else {
-             this->hlink_entity_status_.target_temperature = NAN;
-           }
-         }
-       }});
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::CURRENT_INDOOR_TEMP}}, [this](const HlinkResponseFrame &response) {
-         this->hlink_entity_status_.current_temperature = response.p_value_as_uint16();
+  this->status_.polling_features.push_back(this->make_power_state_request_());
+  this->status_.polling_features.push_back(this->make_mode_request_());
+  this->status_.polling_features.push_back(this->make_target_temp_request_());
+  this->status_.polling_features.push_back(this->make_current_temp_request_());
+  this->status_.polling_features.push_back(this->make_fan_mode_request_());
+}
+
+HlinkRequest HlinkAc::make_power_state_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::POWER_STATE}}, [this](const HlinkResponseFrame &response) {
+            auto power_state = response.p_value_as_uint16();
+            if (power_state.has_value()) {
+              this->hlink_entity_status_.power_state = static_cast<bool>(power_state.value());
+            } else {
+              this->hlink_entity_status_.power_state = {};
+            }
+          }};
+}
+
+HlinkRequest HlinkAc::make_mode_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::MODE}}, [this](const HlinkResponseFrame &response) {
+            if (!this->hlink_entity_status_.power_state.has_value()) {
+              ESP_LOGW(TAG, "Can't handle climate mode response without power state data");
+              return;
+            }
+            this->hlink_entity_status_.hlink_climate_mode = response.p_value_as_uint16();
+            if (!this->hlink_entity_status_.power_state.value()) {
+              // Climate mode should be off when device is turned off
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_OFF;
+              return;
+            }
+            if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_COOL;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_DRY) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_DRY;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_FAN) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_FAN_ONLY;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT_AUTO) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL_AUTO) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_DRY_AUTO) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_AUTO) {
+              this->hlink_entity_status_.mode = esphome::climate::ClimateMode::CLIMATE_MODE_HEAT_COOL;
+            }
+          }};
+}
+
+HlinkRequest HlinkAc::make_target_temp_request_() {
+  return {
+      {HlinkRequestFrame::Type::MT, {FeatureType::TARGET_TEMP}}, [this](const HlinkResponseFrame &response) {
+        if (this->hlink_entity_status_.power_state.has_value() && !this->hlink_entity_status_.power_state.value()) {
+          this->hlink_entity_status_.target_temperature = NAN;
+          return;
+        }
+        if (response.p_value_as_uint16().has_value()) {
+          uint16_t target_temperature = response.p_value_as_uint16().value();
+          if (this->hlink_entity_status_.hlink_climate_mode.has_value() &&
+              this->is_auto_temperature_mode_(this->hlink_entity_status_.hlink_climate_mode.value()) &&
+              target_temperature >= 0xFF00) {
+            // In auto mode the target temperature control is not available
+            // Instead, AC expects temperature offset in range [-3;+3] C
+            // AUTO HEATING: FFFD -> FFFF, FFFE -> FF00, FFFF -> FF01, FF00 -> FF02, FF01 -> FF03, FF02 -> FF04,
+            // FF03 -> FF05
+            // AUTO COOLING: FFFD -> FFFB, FFFE -> FFFC, FFFF -> FFFD, FF00 -> FFFE, FF01 -> FFFF, FF02 -> FF00,
+            // FF03 -> FF01
+            // Needs testing, it's not clear if offset makes any difference in real life
+            int8_t offset_temp = static_cast<int8_t>(target_temperature - 0xFF00);
+            int8_t adjusted_offset = offset_temp;
+            if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_HEAT_AUTO) {
+              adjusted_offset = offset_temp - 2;
+            } else if (this->hlink_entity_status_.hlink_climate_mode == HLINK_MODE_COOL_AUTO) {
+              adjusted_offset = offset_temp + 2;
+            }
+            this->hlink_entity_status_.target_temperature =
+                this->clamp_auto_temperature_(this->reference_temperature_ + adjusted_offset);
+          } else if (target_temperature >= PROTOCOL_TARGET_TEMP_MIN && target_temperature <= PROTOCOL_TARGET_TEMP_MAX) {
+            this->hlink_entity_status_.target_temperature = target_temperature;
+          } else {
+            this->hlink_entity_status_.target_temperature = NAN;
+          }
+        }
+      }};
+}
+
+HlinkRequest HlinkAc::make_current_temp_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::CURRENT_INDOOR_TEMP}},
+          [this](const HlinkResponseFrame &response) {
+            this->hlink_entity_status_.current_temperature = response.p_value_as_uint16();
 #ifdef USE_SENSOR
-         this->update_sensor_state_(this->indoor_temperature_sensor_,
-                                    this->hlink_entity_status_.current_temperature.value_or(NAN));
+            this->update_sensor_state_(this->indoor_temperature_sensor_,
+                                       this->hlink_entity_status_.current_temperature.value_or(NAN));
 #endif
-       }});
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::FAN_MODE}}, [this](const HlinkResponseFrame &response) {
-         if (response.p_value_as_uint16() == HLINK_FAN_AUTO) {
-           this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_AUTO;
-         } else if (response.p_value_as_uint16() == HLINK_FAN_HIGH) {
-           this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_HIGH;
-         } else if (response.p_value_as_uint16() == HLINK_FAN_MEDIUM) {
-           this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_MEDIUM;
-         } else if (response.p_value_as_uint16() == HLINK_FAN_LOW) {
-           this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_LOW;
-         } else if (response.p_value_as_uint16() == HLINK_FAN_QUIET) {
-           this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_QUIET;
-         }
-       }});
+          }};
+}
+
+HlinkRequest HlinkAc::make_fan_mode_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::FAN_MODE}}, [this](const HlinkResponseFrame &response) {
+            if (response.p_value_as_uint16() == HLINK_FAN_AUTO) {
+              this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_AUTO;
+            } else if (response.p_value_as_uint16() == HLINK_FAN_HIGH) {
+              this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_HIGH;
+            } else if (response.p_value_as_uint16() == HLINK_FAN_MEDIUM) {
+              this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_MEDIUM;
+            } else if (response.p_value_as_uint16() == HLINK_FAN_LOW) {
+              this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_LOW;
+            } else if (response.p_value_as_uint16() == HLINK_FAN_QUIET) {
+              this->hlink_entity_status_.fan_mode = esphome::climate::ClimateFanMode::CLIMATE_FAN_QUIET;
+            }
+          }};
 }
 
 void HlinkAc::setup() {
@@ -119,7 +135,7 @@ void HlinkAc::setup() {
   if (this->rtc_.load(&recovered_settings)) {
     beeper_enabled = recovered_settings.beeper_enabled;
     this->stored_target_temperatures_.heat_target_temperature = this->restore_target_temperature_(
-        recovered_settings.heat_target_temperature, this->auto_min_temperature_(), this->auto_max_temperature_());
+        recovered_settings.heat_target_temperature, PROTOCOL_TARGET_TEMP_MIN, PROTOCOL_TARGET_TEMP_MAX);
     this->stored_target_temperatures_.cool_target_temperature = this->restore_target_temperature_(
         recovered_settings.cool_target_temperature, PROTOCOL_TARGET_TEMP_MIN, PROTOCOL_TARGET_TEMP_MAX);
     this->stored_target_temperatures_.heat_cool_target_temperature = this->restore_target_temperature_(
@@ -185,9 +201,7 @@ void HlinkAc::set_reference_temperature(float reference_temperature) {
   this->reference_temperature_ = reference_temperature;
 }
 
-void HlinkAc::set_remember_target_temperatures(bool remember) {
-  this->remember_target_temperatures_ = remember;
-}
+void HlinkAc::set_remember_target_temperatures(bool remember) { this->remember_target_temperatures_ = remember; }
 
 void HlinkAc::refresh_non_idle_timeout_(uint32_t non_idle_timeout_limit_ms) {
   this->status_.timeout_counter_started_at_ms = this->current_time_ms();
@@ -212,61 +226,53 @@ bool HlinkAc::can_start_next_polling_() const {
 
 void HlinkAc::request_status_update_() {
   if (this->status_.state == IDLE) {
-    // Launch update sequence
-    this->status_.state = REQUEST_NEXT_STATUS_FEATURE;
-    this->status_.requested_feature_index = 0;
-    this->refresh_non_idle_timeout_(this->status_.polling_features.size() * 500);
+    // Launch a full polling cycle over all configured features
+    this->start_poll_cycle_({this->status_.polling_features, nullptr, IDLE});
   }
+}
+
+void HlinkAc::start_poll_cycle_(PollCycleDefinition def) {
+  this->status_.polling_cycle.start(std::move(def));
+  this->status_.state = REQUEST_NEXT_STATUS_FEATURE;
+  this->refresh_non_idle_timeout_(this->status_.polling_cycle.timeout_ms());
 }
 
 /*
  * Main loop implements a state machine with the following states:
- * 1. INIT - polls power state on first boot; restores stored target temperatures if AC is off.
+ * 1. INIT - starts a minimal polling cycle (power, mode, target and current temperature) on first boot. The cycle is
+ *    retried until a minimal status is received, then the component transitions to RESTORE_TARGET_TEMPERATURES.
  * 2. IDLE - does nothing.
- * 3. REQUEST_NEXT_STATUS_FEATURE - sends a request for the next status feature; the list of requested features is
- *    stored in the polling_features list.
- * 4. REQUEST_LOW_PRIORITY_FEATURE - sends a request for the low-priority feature, if any.
- * 5. READ_FEATURE_RESPONSE - reads a response for the requested hlink feature.
- * 6. PUBLISH_UPDATE_IF_ANY - once all features are read, updates components if there are any changes.
- * 7. CAPTURE_TARGET_TEMPERATURE - stores the last seen target temperature per mode if the corresponding option is
+ * 3. REQUEST_NEXT_STATUS_FEATURE - sends a request for the next feature of the current polling cycle; the cycle
+ *    definition is stored in the polling_cycle.
+ * 4. READ_FEATURE_RESPONSE - reads a response for the requested hlink feature.
+ * 5. POLL_DONE - all features of the current polling cycle were polled; runs the cycle completion hook which decides
+ *    the next state.
+ * 6. RESTORE_TARGET_TEMPERATURES - restores the stored target temperatures if the AC is off; boot transition state.
+ * 7. PUBLISH_UPDATE_IF_ANY - once all features are read, updates components if there are any changes.
+ * 8. CAPTURE_TARGET_TEMPERATURE - stores the last seen target temperature per mode if the corresponding option is
  *    enabled.
- * 8. APPLY_REQUEST - applies the requested climate controls from the queue.
- * 9. ACK_APPLIED_REQUEST - confirms successfully applied control request.
+ * 9. APPLY_REQUEST - applies the requested climate controls from the queue.
+ * 10. ACK_APPLIED_REQUEST - confirms successfully applied control request.
  */
 void HlinkAc::loop() {
   if (this->status_.state == INIT && this->can_send_next_frame_()) {
-    HlinkRequest power_request({HlinkRequestFrame::Type::MT, {FeatureType::POWER_STATE}},
-                               [this](const HlinkResponseFrame &response) {
-                                 auto power_state = response.p_value_as_uint16();
-                                 if (power_state.has_value() && !power_state.value()) {
-                                   this->apply_stored_target_temperatures_();
-                                 }
-                               });
-    this->status_.current_request = make_unique<HlinkRequest>(std::move(power_request));
-    this->write_hlink_frame_(this->status_.current_request->request_frame);
-    this->status_.requested_feature_index = -1;
-    this->status_.state = READ_FEATURE_RESPONSE;
-    this->refresh_non_idle_timeout_(300);
-    return;
+    PollCycleDefinition boot_definition{};
+    boot_definition.features = {this->make_power_state_request_(), this->make_mode_request_(),
+                                this->make_target_temp_request_(), this->make_current_temp_request_()};
+    boot_definition.on_completed = [this]() {
+      return this->hlink_entity_status_.has_minimal_hvac_status() ? RESTORE_TARGET_TEMPERATURES : INIT;
+    };
+    boot_definition.next_state_on_timeout = INIT;
+    this->start_poll_cycle_(std::move(boot_definition));
+    // Continue to the REQUEST_NEXT_STATUS_FEATURE block below to send the first request right away
   }
 
   if (this->status_.state == REQUEST_NEXT_STATUS_FEATURE && this->can_send_next_frame_()) {
-    HlinkRequest state_feature_request = this->status_.get_currently_polling_feature();
+    HlinkRequest state_feature_request = this->status_.polling_cycle.current_request();
     this->status_.current_request = make_unique<HlinkRequest>(state_feature_request);
     this->write_hlink_frame_(state_feature_request.request_frame);
     this->status_.state = READ_FEATURE_RESPONSE;
     return;
-  }
-
-  if (this->status_.state == REQUEST_LOW_PRIORITY_FEATURE && this->can_send_next_frame_()) {
-    if (this->status_.low_priority_hlink_request.has_value()) {
-      HlinkRequest low_priority_feature_request = this->status_.low_priority_hlink_request.value();
-      this->write_hlink_frame_(low_priority_feature_request.request_frame);
-      this->status_.current_request = make_unique<HlinkRequest>(low_priority_feature_request);
-      this->status_.low_priority_hlink_request = {};
-      this->status_.state = READ_FEATURE_RESPONSE;
-      return;
-    }
   }
 
   if (this->status_.state == READ_FEATURE_RESPONSE) {
@@ -278,19 +284,28 @@ void HlinkAc::loop() {
     }
     HlinkRequest requested_feature = *this->status_.current_request;
     if (this->handle_hlink_request_response_(requested_feature, response)) {
-      if (this->status_.requested_feature_index == -1) {
-        // Requested feature index is -1 means that we are handling low priority request
-        this->status_.state = IDLE;
-      } else if (this->status_.requested_feature_index + 1 < this->status_.polling_features.size()) {
+      if (this->status_.polling_cycle.has_more_features()) {
+        this->status_.polling_cycle.advance();
         this->status_.state = REQUEST_NEXT_STATUS_FEATURE;
-        this->status_.requested_feature_index++;
       } else {
-        this->status_.state = PUBLISH_UPDATE_IF_ANY;
-        this->status_.requested_feature_index = -1;
+        this->status_.state = POLL_DONE;
         this->status_.last_status_polling_finished_at_ms = this->current_time_ms();
       }
       this->status_.current_request = nullptr;
     }
+  }
+
+  if (this->status_.state == POLL_DONE) {
+    HlinkComponentState next_state = this->status_.polling_cycle.dispatch_completion();
+    this->status_.polling_cycle.clear();
+    this->status_.state = next_state;
+    return;
+  }
+
+  if (this->status_.state == RESTORE_TARGET_TEMPERATURES) {
+    this->apply_restored_target_temperatures_if_needed_();
+    this->status_.state = PUBLISH_UPDATE_IF_ANY;
+    return;
   }
 
   if (this->status_.state == PUBLISH_UPDATE_IF_ANY) {
@@ -338,26 +353,30 @@ void HlinkAc::loop() {
     }
   }
 
-  // Reset status to IDLE if we reached timeout deadline
+  // Reset status if we reached timeout deadline
   if (this->status_.state != IDLE && this->reached_timeout_threshold_()) {
-    ESP_LOGW(TAG, "Reached global timeout threshold while performing [%s] state action. Go to IDLE.",
-             this->status_.state == REQUEST_NEXT_STATUS_FEATURE    ? "REQUEST_NEXT_STATUS_FEATURE"
-             : this->status_.state == REQUEST_LOW_PRIORITY_FEATURE ? "REQUEST_LOW_PRIORITY_FEATURE"
-             : this->status_.state == READ_FEATURE_RESPONSE        ? "READ_FEATURE_RESPONSE"
-             : this->status_.state == PUBLISH_UPDATE_IF_ANY        ? "PUBLISH_UPDATE_IF_ANY"
-             : this->status_.state == CAPTURE_TARGET_TEMPERATURE   ? "CAPTURE_TARGET_TEMPERATURE"
-             : this->status_.state == APPLY_REQUEST                ? "APPLY_REQUEST"
-             : this->status_.state == ACK_APPLIED_REQUEST          ? "ACK_APPLIED_REQUEST"
-                                                                   : "UNKNOWN");
+    ESP_LOGW(TAG, "Reached global timeout threshold while performing [%s] state action.",
+             this->status_.state == REQUEST_NEXT_STATUS_FEATURE   ? "REQUEST_NEXT_STATUS_FEATURE"
+             : this->status_.state == READ_FEATURE_RESPONSE       ? "READ_FEATURE_RESPONSE"
+             : this->status_.state == POLL_DONE                   ? "POLL_DONE"
+             : this->status_.state == RESTORE_TARGET_TEMPERATURES ? "RESTORE_TARGET_TEMPERATURES"
+             : this->status_.state == PUBLISH_UPDATE_IF_ANY       ? "PUBLISH_UPDATE_IF_ANY"
+             : this->status_.state == CAPTURE_TARGET_TEMPERATURE  ? "CAPTURE_TARGET_TEMPERATURE"
+             : this->status_.state == APPLY_REQUEST               ? "APPLY_REQUEST"
+             : this->status_.state == ACK_APPLIED_REQUEST         ? "ACK_APPLIED_REQUEST"
+                                                                  : "UNKNOWN");
     ESP_LOGW(
         TAG,
-        "Component state: requested_feature_index=%d, non_idle_timeout_limit_ms=%lu, "
+        "Component state: polling_cycle_active=%s, polling_cycle_index=%d, non_idle_timeout_limit_ms=%lu, "
         "last_status_polling_finished_at_ms=%lu, last_frame_received_at_ms=%lu, timeout_counter_started_at_ms=%lu, "
         "requests_left_to_apply=%u, pending_action_requests_size=%d, pending_low_priority_hlink_request=%s",
-        this->status_.requested_feature_index, this->status_.non_idle_timeout_limit_ms,
-        this->status_.last_status_polling_finished_at_ms, this->status_.last_frame_received_at_ms,
-        this->status_.timeout_counter_started_at_ms, this->status_.requests_left_to_apply,
-        this->pending_action_requests_.size(), this->status_.low_priority_hlink_request.has_value() ? "YES" : "NO");
+        this->status_.polling_cycle.is_active() ? "YES" : "NO",
+        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.get_requested_feature_index_for_debug()
+                                                : -1,
+        this->status_.non_idle_timeout_limit_ms, this->status_.last_status_polling_finished_at_ms,
+        this->status_.last_frame_received_at_ms, this->status_.timeout_counter_started_at_ms,
+        this->status_.requests_left_to_apply, this->pending_action_requests_.size(),
+        this->status_.low_priority_hlink_request.has_value() ? "YES" : "NO");
     if (this->status_.current_request != nullptr) {
       ESP_LOGW(TAG, "Request time out: [%s - %04X,%s]",
                this->status_.current_request->request_frame.type == HlinkRequestFrame::Type::MT ? "MT" : "ST",
@@ -378,7 +397,10 @@ void HlinkAc::loop() {
     while (!this->pending_action_requests_.is_empty()) {
       this->pending_action_requests_.dequeue();
     }
+    HlinkComponentState next_state =
+        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.next_state_on_timeout() : IDLE;
     this->status_.reset_state();
+    this->status_.state = next_state;
   }
 
   // If there are any pending requests - apply them ASAP
@@ -402,10 +424,14 @@ void HlinkAc::loop() {
     this->request_status_update_();
   }
 
-  // Request low priority feature if idling and nothing else to do
+  // Request low priority feature if idling and nothing else to do. Modeled as a single-feature polling cycle.
   if (this->status_.state == IDLE && this->status_.low_priority_hlink_request.has_value()) {
-    this->status_.state = REQUEST_LOW_PRIORITY_FEATURE;
-    this->refresh_non_idle_timeout_(300);
+    PollCycleDefinition low_priority_definition{};
+    low_priority_definition.features.push_back(this->status_.low_priority_hlink_request.value());
+    low_priority_definition.on_completed = []() { return IDLE; };
+    low_priority_definition.next_state_on_timeout = IDLE;
+    this->status_.low_priority_hlink_request = {};
+    this->start_poll_cycle_(std::move(low_priority_definition));
   }
 }
 
@@ -840,27 +866,38 @@ void HlinkAc::set_supported_climate_modes(esphome::climate::ClimateModeMask mode
   this->traits_.set_supported_modes(modes);
 }
 
+HlinkRequest HlinkAc::make_swing_mode_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::SWING_MODE}}, [this](const HlinkResponseFrame &response) {
+            if (response.p_value_as_uint16() == HLINK_SWING_OFF) {
+              this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_OFF;
+            } else if (response.p_value_as_uint16() == HLINK_SWING_VERTICAL) {
+              this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_VERTICAL;
+            } else if (response.p_value_as_uint16() == HLINK_SWING_HORIZONTAL) {
+              this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_HORIZONTAL;
+            } else if (response.p_value_as_uint16() == HLINK_SWING_BOTH) {
+              this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_BOTH;
+            }
+          }};
+}
+
 void HlinkAc::set_supported_swing_modes(esphome::climate::ClimateSwingModeMask modes) {
   this->traits_.set_supported_swing_modes(modes);
   if (modes.size() == 1 && modes.count(climate::ClimateSwingMode::CLIMATE_SWING_OFF)) {
     return;  // If the only supported swing mode is OFF, we don't need to add polling for swing mode status
   }
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {FeatureType::SWING_MODE}}, [this](const HlinkResponseFrame &response) {
-         if (response.p_value_as_uint16() == HLINK_SWING_OFF) {
-           this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_OFF;
-         } else if (response.p_value_as_uint16() == HLINK_SWING_VERTICAL) {
-           this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_VERTICAL;
-         } else if (response.p_value_as_uint16() == HLINK_SWING_HORIZONTAL) {
-           this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_HORIZONTAL;
-         } else if (response.p_value_as_uint16() == HLINK_SWING_BOTH) {
-           this->hlink_entity_status_.swing_mode = esphome::climate::ClimateSwingMode::CLIMATE_SWING_BOTH;
-         }
-       }});
+  this->status_.polling_features.push_back(this->make_swing_mode_request_());
 }
 
 void HlinkAc::set_supported_fan_modes(esphome::climate::ClimateFanModeMask modes) {
   this->traits_.set_supported_fan_modes(modes);
+}
+
+HlinkRequest HlinkAc::make_leave_home_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::LEAVE_HOME_STATUS_READ}},
+          [this](const HlinkResponseFrame &response) {
+            this->hlink_entity_status_.leave_home_enabled =
+                response.p_value.has_value() && response.p_value.value().back() == HLINK_LEAVE_HOME_ENABLED;
+          }};
 }
 
 void HlinkAc::set_supported_climate_presets(esphome::climate::ClimatePresetMask presets) {
@@ -869,43 +906,41 @@ void HlinkAc::set_supported_climate_presets(esphome::climate::ClimatePresetMask 
     this->traits_.add_supported_preset(climate::ClimatePreset::CLIMATE_PRESET_NONE);
   }
   if (presets.count(climate::ClimatePreset::CLIMATE_PRESET_AWAY)) {
-    this->status_.polling_features.push_back({{HlinkRequestFrame::Type::MT, {FeatureType::LEAVE_HOME_STATUS_READ}},
-                                              [this](const HlinkResponseFrame &response) {
-                                                this->hlink_entity_status_.leave_home_enabled =
-                                                    response.p_value.has_value() &&
-                                                    response.p_value.value().back() == HLINK_LEAVE_HOME_ENABLED;
-                                              }});
+    this->status_.polling_features.push_back(this->make_leave_home_request_());
   }
+}
+
+HlinkRequest HlinkAc::make_activity_status_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::ACTIVITY_STATUS}}, [this](const HlinkResponseFrame &response) {
+            if (this->hlink_entity_status_.hlink_climate_mode.has_value() &&
+                this->hlink_entity_status_.power_state.has_value()) {
+              auto is_powered_on = this->hlink_entity_status_.power_state.value();
+              auto is_active = response.p_value_as_uint16() == HLINK_ACTIVE_ON;
+              auto hlink_climate_mode = this->hlink_entity_status_.hlink_climate_mode.value();
+              if (!is_powered_on) {
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_OFF;
+              } else if (is_active &&
+                         (hlink_climate_mode == HLINK_MODE_COOL || hlink_climate_mode == HLINK_MODE_COOL_AUTO)) {
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_COOLING;
+              } else if (is_active &&
+                         (hlink_climate_mode == HLINK_MODE_HEAT || hlink_climate_mode == HLINK_MODE_HEAT_AUTO)) {
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_HEATING;
+              } else if (is_active && hlink_climate_mode == HLINK_MODE_DRY) {
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_DRYING;
+              } else if (hlink_climate_mode == HLINK_MODE_FAN) {
+                // Activity status is always 0x0000 in fan mode
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_FAN;
+              } else {
+                this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_IDLE;
+              }
+            }
+          }};
 }
 
 void HlinkAc::set_support_hvac_actions(bool support_hvac_actions) {
   if (support_hvac_actions) {
     this->traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
-    this->status_.polling_features.push_back(
-        {{HlinkRequestFrame::Type::MT, {FeatureType::ACTIVITY_STATUS}}, [this](const HlinkResponseFrame &response) {
-           if (this->hlink_entity_status_.hlink_climate_mode.has_value() &&
-               this->hlink_entity_status_.power_state.has_value()) {
-             auto is_powered_on = this->hlink_entity_status_.power_state.value();
-             auto is_active = response.p_value_as_uint16() == HLINK_ACTIVE_ON;
-             auto hlink_climate_mode = this->hlink_entity_status_.hlink_climate_mode.value();
-             if (!is_powered_on) {
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_OFF;
-             } else if (is_active &&
-                        (hlink_climate_mode == HLINK_MODE_COOL || hlink_climate_mode == HLINK_MODE_COOL_AUTO)) {
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_COOLING;
-             } else if (is_active &&
-                        (hlink_climate_mode == HLINK_MODE_HEAT || hlink_climate_mode == HLINK_MODE_HEAT_AUTO)) {
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_HEATING;
-             } else if (is_active && hlink_climate_mode == HLINK_MODE_DRY) {
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_DRYING;
-             } else if (hlink_climate_mode == HLINK_MODE_FAN) {
-               // Activity status is always 0x0000 in fan mode
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_FAN;
-             } else {
-               this->hlink_entity_status_.action = esphome::climate::ClimateAction::CLIMATE_ACTION_IDLE;
-             }
-           }
-         }});
+    this->status_.polling_features.push_back(this->make_activity_status_request_());
   }
 }
 
@@ -915,21 +950,24 @@ esphome::climate::ClimateTraits HlinkAc::traits() {
 }
 
 #ifdef USE_SWITCH
+HlinkRequest HlinkAc::make_remote_control_lock_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::REMOTE_CONTROL_LOCK}},
+          [this](const HlinkResponseFrame &response) {
+            auto remote_control_lock = response.p_value_as_uint16();
+            if (remote_control_lock.has_value()) {
+              this->hlink_entity_status_.remote_control_lock = static_cast<bool>(remote_control_lock.value());
+            } else {
+              this->hlink_entity_status_.remote_control_lock = {};
+            }
+          }};
+}
+
 void HlinkAc::set_remote_lock_switch(switch_::Switch *sw) {
   this->remote_lock_switch_ = sw;
   if (this->hlink_entity_status_.remote_control_lock.has_value()) {
     this->remote_lock_switch_->publish_state(this->hlink_entity_status_.remote_control_lock.value());
   }
-  this->status_.polling_features.push_back({{HlinkRequestFrame::Type::MT, {FeatureType::REMOTE_CONTROL_LOCK}},
-                                            [this, sw](const HlinkResponseFrame &response) {
-                                              auto remote_control_lock = response.p_value_as_uint16();
-                                              if (remote_control_lock.has_value()) {
-                                                this->hlink_entity_status_.remote_control_lock =
-                                                    static_cast<bool>(remote_control_lock.value());
-                                              } else {
-                                                this->hlink_entity_status_.remote_control_lock = {};
-                                              }
-                                            }});
+  this->status_.polling_features.push_back(this->make_remote_control_lock_request_());
 }
 
 void HlinkAc::set_remote_lock_state(bool state) {
@@ -957,18 +995,21 @@ void HlinkAc::handle_beep_state_change(bool state) {
 #endif
 
 #ifdef USE_SENSOR
+HlinkRequest HlinkAc::make_current_outdoor_temp_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::CURRENT_OUTDOOR_TEMP}},
+          [this](const HlinkResponseFrame &response) {
+            optional<int8_t> raw_sensor_value = response.p_value_as_int8();
+            float sensor_value =
+                (raw_sensor_value.has_value() && raw_sensor_value != 0x7E) ? raw_sensor_value.value() : NAN;
+            this->update_sensor_state_(this->outdoor_temperature_sensor_, sensor_value);
+          }};
+}
+
 void HlinkAc::set_sensor(SensorType type, sensor::Sensor *s) {
   switch (type) {
     case SensorType::OUTDOOR_TEMPERATURE:
-      this->status_.polling_features.push_back({{HlinkRequestFrame::Type::MT, {FeatureType::CURRENT_OUTDOOR_TEMP}},
-                                                [this, s](const HlinkResponseFrame &response) {
-                                                  optional<int8_t> raw_sensor_value = response.p_value_as_int8();
-                                                  float sensor_value =
-                                                      (raw_sensor_value.has_value() && raw_sensor_value != 0x7E)
-                                                          ? raw_sensor_value.value()
-                                                          : NAN;
-                                                  this->update_sensor_state_(s, sensor_value);
-                                                }});
+      this->outdoor_temperature_sensor_ = s;
+      this->status_.polling_features.push_back(this->make_current_outdoor_temp_request_());
       break;
     case SensorType::INDOOR_TEMPERATURE:
       this->indoor_temperature_sensor_ = s;
@@ -993,17 +1034,21 @@ void HlinkAc::update_sensor_state_(sensor::Sensor *sensor, float value) {
 }
 #endif
 #ifdef USE_BINARY_SENSOR
+HlinkRequest HlinkAc::make_air_filter_warning_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::AIR_FILTER_WARNING}}, [this](const HlinkResponseFrame &response) {
+            optional<int8_t> raw_sensor_value = response.p_value_as_int8();
+            if (raw_sensor_value.has_value()) {
+              bool sensor_value = raw_sensor_value.value() != 0;
+              this->air_filter_warning_sensor_->publish_state(sensor_value);
+            }
+          }};
+}
+
 void HlinkAc::set_binary_sensor(BinarySensorType type, binary_sensor::BinarySensor *bs) {
   switch (type) {
     case BinarySensorType::AIR_FILTER_WARNING:
-      this->status_.polling_features.push_back({{HlinkRequestFrame::Type::MT, {FeatureType::AIR_FILTER_WARNING}},
-                                                [this, bs](const HlinkResponseFrame &response) {
-                                                  optional<int8_t> raw_sensor_value = response.p_value_as_int8();
-                                                  if (raw_sensor_value.has_value()) {
-                                                    bool sensor_value = raw_sensor_value.value() != 0;
-                                                    bs->publish_state(sensor_value);
-                                                  }
-                                                }});
+      this->air_filter_warning_sensor_ = bs;
+      this->status_.polling_features.push_back(this->make_air_filter_warning_request_());
       break;
     default:
       break;
@@ -1011,32 +1056,38 @@ void HlinkAc::set_binary_sensor(BinarySensorType type, binary_sensor::BinarySens
 }
 #endif
 #ifdef USE_TEXT_SENSOR
+HlinkRequest HlinkAc::make_model_name_request_() {
+  return {{HlinkRequestFrame::Type::MT, {FeatureType::MODEL_NAME}}, [this](const HlinkResponseFrame &response) {
+            if (response.p_value.has_value()) {
+              this->hlink_entity_status_.model_name = std::string(response.p_value->begin(), response.p_value->end());
+            }
+          }};
+}
+
 void HlinkAc::set_text_sensor(TextSensorType type, text_sensor::TextSensor *text_sensor) {
   switch (type) {
     case TextSensorType::MODEL_NAME:
       this->model_name_text_sensor_ = text_sensor;
-      this->status_.polling_features.push_back(
-          {{HlinkRequestFrame::Type::MT, {FeatureType::MODEL_NAME}}, [this](const HlinkResponseFrame &response) {
-             if (response.p_value.has_value()) {
-               this->hlink_entity_status_.model_name = std::string(response.p_value->begin(), response.p_value->end());
-             }
-           }});
+      this->status_.polling_features.push_back(this->make_model_name_request_());
       break;
     default:
       break;
   }
 }
 
+HlinkRequest HlinkAc::make_debug_request_(uint16_t address, text_sensor::TextSensor *sens) {
+  return {{HlinkRequestFrame::Type::MT, {address}}, [sens](const HlinkResponseFrame &response) {
+            if (response.p_value.has_value()) {
+              std::string response_value = response.p_value_as_string().value();
+              if (sens->state != response_value) {
+                sens->publish_state(response_value);
+              }
+            }
+          }};
+}
+
 void HlinkAc::set_debug_text_sensor(uint16_t address, text_sensor::TextSensor *text_sensor) {
-  this->status_.polling_features.push_back(
-      {{HlinkRequestFrame::Type::MT, {address}}, [text_sensor](const HlinkResponseFrame &response) {
-         if (response.p_value.has_value()) {
-           std::string response_value = response.p_value_as_string().value();
-           if (text_sensor->state != response_value) {
-             text_sensor->publish_state(response_value);
-           }
-         }
-       }});
+  this->status_.polling_features.push_back(this->make_debug_request_(address, text_sensor));
 }
 
 void HlinkAc::set_debug_discovery_text_sensor(text_sensor::TextSensor *ts) { this->debug_discovery_text_sensor_ = ts; }
@@ -1219,6 +1270,12 @@ void HlinkAc::apply_stored_target_temperatures_() {
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_AUTO));
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP, encoded));
+  }
+}
+
+void HlinkAc::apply_restored_target_temperatures_if_needed_() {
+  if (this->hlink_entity_status_.power_state.has_value() && !this->hlink_entity_status_.power_state.value()) {
+    this->apply_stored_target_temperatures_();
   }
 }
 

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -228,8 +228,10 @@ void HlinkAc::request_status_update_() {
  * 4. REQUEST_LOW_PRIORITY_FEATURE - sends a request for the low-priority feature, if any.
  * 5. READ_FEATURE_RESPONSE - reads a response for the requested hlink feature.
  * 6. PUBLISH_UPDATE_IF_ANY - once all features are read, updates components if there are any changes.
- * 7. APPLY_REQUEST - applies the requested climate controls from the queue.
- * 8. ACK_APPLIED_REQUEST - confirms successfully applied control request.
+ * 7. CAPTURE_TARGET_TEMPERATURE - stores the last seen target temperature per mode if the corresponding option is
+ *    enabled.
+ * 8. APPLY_REQUEST - applies the requested climate controls from the queue.
+ * 9. ACK_APPLIED_REQUEST - confirms successfully applied control request.
  */
 void HlinkAc::loop() {
   if (this->status_.state == INIT && this->can_send_next_frame_()) {
@@ -293,6 +295,12 @@ void HlinkAc::loop() {
 
   if (this->status_.state == PUBLISH_UPDATE_IF_ANY) {
     this->publish_updates_if_any_();
+    this->status_.state = CAPTURE_TARGET_TEMPERATURE;
+    return;
+  }
+
+  if (this->status_.state == CAPTURE_TARGET_TEMPERATURE) {
+    this->capture_target_temperature_from_status_();
     this->status_.state = IDLE;
     return;
   }
@@ -337,6 +345,7 @@ void HlinkAc::loop() {
              : this->status_.state == REQUEST_LOW_PRIORITY_FEATURE ? "REQUEST_LOW_PRIORITY_FEATURE"
              : this->status_.state == READ_FEATURE_RESPONSE        ? "READ_FEATURE_RESPONSE"
              : this->status_.state == PUBLISH_UPDATE_IF_ANY        ? "PUBLISH_UPDATE_IF_ANY"
+             : this->status_.state == CAPTURE_TARGET_TEMPERATURE   ? "CAPTURE_TARGET_TEMPERATURE"
              : this->status_.state == APPLY_REQUEST                ? "APPLY_REQUEST"
              : this->status_.state == ACK_APPLIED_REQUEST          ? "ACK_APPLIED_REQUEST"
                                                                    : "UNKNOWN");
@@ -1116,31 +1125,46 @@ void HlinkAc::capture_target_temperature_(climate::ClimateMode mode, float tempe
   if (!this->remember_target_temperatures_) {
     return;
   }
-  bool updated = false;
+  optional<float> *target_temperature = nullptr;
   switch (mode) {
     case climate::ClimateMode::CLIMATE_MODE_HEAT:
-      this->stored_target_temperatures_.heat_target_temperature = temperature;
-      updated = true;
+      target_temperature = &this->stored_target_temperatures_.heat_target_temperature;
       break;
     case climate::ClimateMode::CLIMATE_MODE_COOL:
-      this->stored_target_temperatures_.cool_target_temperature = temperature;
-      updated = true;
+      target_temperature = &this->stored_target_temperatures_.cool_target_temperature;
       break;
     case climate::ClimateMode::CLIMATE_MODE_DRY:
-      this->stored_target_temperatures_.dry_target_temperature = temperature;
-      updated = true;
+      target_temperature = &this->stored_target_temperatures_.dry_target_temperature;
       break;
     case climate::ClimateMode::CLIMATE_MODE_HEAT_COOL:
-      this->stored_target_temperatures_.heat_cool_target_temperature = temperature;
-      updated = true;
+      target_temperature = &this->stored_target_temperatures_.heat_cool_target_temperature;
       break;
     default:
       // OFF and FAN_ONLY modes don't have a target temperature.
-      break;
+      return;
   }
-  if (updated) {
-    this->save_settings_();
+  if (target_temperature->has_value() && this->is_nanable_equal_(target_temperature->value(), temperature)) {
+    return;
   }
+  *target_temperature = temperature;
+  this->save_settings_();
+}
+
+void HlinkAc::capture_target_temperature_from_status_() {
+  if (!this->hlink_entity_status_.has_minimal_hvac_status()) {
+    return;
+  }
+  if (std::isnan(this->hlink_entity_status_.target_temperature.value())) {
+    return;
+  }
+  if (this->hlink_entity_status_.leave_home_enabled.value_or(false) &&
+      this->hlink_entity_status_.power_state.value_or(false) &&
+      this->hlink_entity_status_.target_temperature.value() == 10) {
+    // Away (leave home) mode uses target temperature 10 as a marker, don't remember it.
+    return;
+  }
+  this->capture_target_temperature_(this->hlink_entity_status_.mode.value(),
+                                    this->hlink_entity_status_.target_temperature.value());
 }
 
 optional<float> HlinkAc::restore_target_temperature_(float value, float min_temperature, float max_temperature) const {

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -1207,9 +1207,8 @@ void HlinkAc::capture_target_temperature_from_status_() {
   if (std::isnan(this->hlink_entity_status_.target_temperature.value())) {
     return;
   }
-  if (this->hlink_entity_status_.leave_home_enabled.value_or(false) &&
-      this->hlink_entity_status_.power_state.value_or(false) &&
-      this->hlink_entity_status_.target_temperature.value() == 10) {
+  if (this->hlink_entity_status_.mode.value() == climate::ClimateMode::CLIMATE_MODE_HEAT &&
+      this->hlink_entity_status_.target_temperature.value() == PROTOCOL_TARGET_TEMP_MIN) {
     // Away (leave home) mode uses target temperature 10 as a marker, don't remember it.
     return;
   }

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -772,9 +772,6 @@ void HlinkAc::control(const esphome::climate::ClimateCall &call) {
                              }
                              this->publish_state();
                            });
-    // The AC may resume an unexpected state (e.g. its last remembered one or a factory default) when it is turned on
-    // or switched to another mode, so fill in the last remembered target temperature when the call doesn't specify
-    // one. Re-selecting the mode the AC is already running in is skipped.
     if (power_state && this->remember_target_temperatures_ &&
         (!this->hlink_entity_status_.power_state.value_or(false) ||
          this->hlink_entity_status_.mode.value_or(esphome::climate::ClimateMode::CLIMATE_MODE_OFF) != mode) &&
@@ -1192,22 +1189,10 @@ void HlinkAc::save_settings_() {
   }
 }
 
-void HlinkAc::capture_target_temperature_(climate::ClimateMode mode, float temperature) {
+void HlinkAc::capture_target_temperature_from_status_() {
   if (!this->remember_target_temperatures_) {
     return;
   }
-  optional<float> *target_temperature = this->stored_target_temperature_for_(mode);
-  if (target_temperature == nullptr) {
-    return;
-  }
-  if (target_temperature->has_value() && this->is_nanable_equal_(target_temperature->value(), temperature)) {
-    return;
-  }
-  *target_temperature = temperature;
-  this->save_settings_();
-}
-
-void HlinkAc::capture_target_temperature_from_status_() {
   if (!this->hlink_entity_status_.has_minimal_hvac_status()) {
     return;
   }
@@ -1223,7 +1208,16 @@ void HlinkAc::capture_target_temperature_from_status_() {
     // Away (leave home) mode uses target temperature 10 as a marker, don't remember it.
     return;
   }
-  this->capture_target_temperature_(mode, reported_target_temperature);
+  optional<float> *target_temperature = this->stored_target_temperature_for_(mode);
+  if (target_temperature == nullptr) {
+    return;
+  }
+  if (target_temperature->has_value() &&
+      this->is_nanable_equal_(target_temperature->value(), reported_target_temperature)) {
+    return;
+  }
+  *target_temperature = reported_target_temperature;
+  this->save_settings_();
 }
 
 optional<float> *HlinkAc::stored_target_temperature_for_(climate::ClimateMode mode) {

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -111,12 +111,21 @@ HlinkAc::HlinkAc() {
 }
 
 void HlinkAc::setup() {
-  constexpr uint32_t settings_version = 0xA7C3B2E4;
+  // Version must be bumped when the settings struct layout changes.
+  constexpr uint32_t settings_version = 0x5E6C7A8B;
   this->rtc_ = this->make_entity_preference<HlinkAcSettings>(settings_version);
   HlinkAcSettings recovered_settings{};
   auto beeper_enabled = false;
   if (this->rtc_.load(&recovered_settings)) {
     beeper_enabled = recovered_settings.beeper_enabled;
+    this->stored_target_temperatures_.heat_target_temperature = this->restore_target_temperature_(
+        recovered_settings.heat_target_temperature, this->auto_min_temperature_(), this->auto_max_temperature_());
+    this->stored_target_temperatures_.cool_target_temperature = this->restore_target_temperature_(
+        recovered_settings.cool_target_temperature, PROTOCOL_TARGET_TEMP_MIN, PROTOCOL_TARGET_TEMP_MAX);
+    this->stored_target_temperatures_.heat_cool_target_temperature = this->restore_target_temperature_(
+        recovered_settings.heat_cool_target_temperature, this->auto_min_temperature_(), this->auto_max_temperature_());
+    this->stored_target_temperatures_.dry_target_temperature = this->restore_target_temperature_(
+        recovered_settings.dry_target_temperature, PROTOCOL_TARGET_TEMP_MIN, PROTOCOL_TARGET_TEMP_MAX);
   }
 #ifdef USE_SWITCH
   if (this->beeper_switch_ != nullptr && beeper_enabled != this->beeper_switch_->state) {
@@ -176,8 +185,8 @@ void HlinkAc::set_reference_temperature(float reference_temperature) {
   this->reference_temperature_ = reference_temperature;
 }
 
-void HlinkAc::set_initial_target_temperatures(const InitialTargetTemperatures &config) {
-  this->initial_target_temperatures_ = config;
+void HlinkAc::set_remember_target_temperatures(bool remember) {
+  this->remember_target_temperatures_ = remember;
 }
 
 void HlinkAc::refresh_non_idle_timeout_(uint32_t non_idle_timeout_limit_ms) {
@@ -212,7 +221,7 @@ void HlinkAc::request_status_update_() {
 
 /*
  * Main loop implements a state machine with the following states:
- * 1. INIT - polls power state on first boot; applies initial target temperatures if AC is off.
+ * 1. INIT - polls power state on first boot; restores stored target temperatures if AC is off.
  * 2. IDLE - does nothing.
  * 3. REQUEST_NEXT_STATUS_FEATURE - sends a request for the next status feature; the list of requested features is
  *    stored in the polling_features list.
@@ -228,7 +237,7 @@ void HlinkAc::loop() {
                                [this](const HlinkResponseFrame &response) {
                                  auto power_state = response.p_value_as_uint16();
                                  if (power_state.has_value() && !power_state.value()) {
-                                   this->apply_initial_target_temperatures_();
+                                   this->apply_stored_target_temperatures_();
                                  }
                                });
     this->status_.current_request = make_unique<HlinkRequest>(std::move(power_request));
@@ -755,6 +764,7 @@ void HlinkAc::control(const esphome::climate::ClimateCall &call) {
       target_temperature = this->clamp_auto_temperature_(target_temperature);
       hlink_target_temperature = this->encode_auto_temperature_(target_temperature);
     }
+    this->capture_target_temperature_(requested_mode, target_temperature);
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP, hlink_target_temperature),
         [this, target_temperature](const HlinkResponseFrame &response) {
@@ -1090,46 +1100,98 @@ void HlinkAc::save_settings_() {
     beeper_enabled = this->beeper_switch_->state;
   }
 #endif
-  HlinkAcSettings settings{beeper_enabled, 0};
+  HlinkAcSettings settings{
+      beeper_enabled,
+      this->stored_target_temperatures_.heat_target_temperature.value_or(NAN),
+      this->stored_target_temperatures_.cool_target_temperature.value_or(NAN),
+      this->stored_target_temperatures_.heat_cool_target_temperature.value_or(NAN),
+      this->stored_target_temperatures_.dry_target_temperature.value_or(NAN),
+  };
   if (!this->rtc_.save(&settings)) {
     ESP_LOGW(TAG, "Failed to save settings");
   }
 }
 
-void HlinkAc::apply_initial_target_temperatures_() {
-  if (this->initial_target_temperatures_.heat_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Setting initial heat target temperature: %.1f",
-             this->initial_target_temperatures_.heat_target_temperature.value());
+void HlinkAc::capture_target_temperature_(climate::ClimateMode mode, float temperature) {
+  if (!this->remember_target_temperatures_) {
+    return;
+  }
+  bool updated = false;
+  switch (mode) {
+    case climate::ClimateMode::CLIMATE_MODE_HEAT:
+      this->stored_target_temperatures_.heat_target_temperature = temperature;
+      updated = true;
+      break;
+    case climate::ClimateMode::CLIMATE_MODE_COOL:
+      this->stored_target_temperatures_.cool_target_temperature = temperature;
+      updated = true;
+      break;
+    case climate::ClimateMode::CLIMATE_MODE_DRY:
+      this->stored_target_temperatures_.dry_target_temperature = temperature;
+      updated = true;
+      break;
+    case climate::ClimateMode::CLIMATE_MODE_HEAT_COOL:
+      this->stored_target_temperatures_.heat_cool_target_temperature = temperature;
+      updated = true;
+      break;
+    default:
+      // OFF and FAN_ONLY modes don't have a target temperature.
+      break;
+  }
+  if (updated) {
+    this->save_settings_();
+  }
+}
+
+optional<float> HlinkAc::restore_target_temperature_(float value, float min_temperature, float max_temperature) const {
+  if (std::isnan(value)) {
+    return {};
+  }
+  if (value < min_temperature || value > max_temperature) {
+    ESP_LOGW(TAG, "Stored target temperature %.1f is out of range [%.1f; %.1f], ignoring it", value, min_temperature,
+             max_temperature);
+    return {};
+  }
+  return value;
+}
+
+void HlinkAc::apply_stored_target_temperatures_() {
+  if (!this->remember_target_temperatures_) {
+    return;
+  }
+  if (this->stored_target_temperatures_.heat_target_temperature.has_value()) {
+    ESP_LOGI(TAG, "Restoring last set heat target temperature: %.1f",
+             this->stored_target_temperatures_.heat_target_temperature.value());
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_HEAT));
     this->enqueue_request_(HlinkRequestFrame::with_uint16(
         HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->initial_target_temperatures_.heat_target_temperature.value())));
+        static_cast<uint16_t>(this->stored_target_temperatures_.heat_target_temperature.value())));
   }
-  if (this->initial_target_temperatures_.cool_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Setting initial cool target temperature: %.1f",
-             this->initial_target_temperatures_.cool_target_temperature.value());
+  if (this->stored_target_temperatures_.cool_target_temperature.has_value()) {
+    ESP_LOGI(TAG, "Restoring last set cool target temperature: %.1f",
+             this->stored_target_temperatures_.cool_target_temperature.value());
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_COOL));
     this->enqueue_request_(HlinkRequestFrame::with_uint16(
         HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->initial_target_temperatures_.cool_target_temperature.value())));
+        static_cast<uint16_t>(this->stored_target_temperatures_.cool_target_temperature.value())));
   }
-  if (this->initial_target_temperatures_.dry_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Setting initial dry target temperature: %.1f",
-             this->initial_target_temperatures_.dry_target_temperature.value());
+  if (this->stored_target_temperatures_.dry_target_temperature.has_value()) {
+    ESP_LOGI(TAG, "Restoring last set dry target temperature: %.1f",
+             this->stored_target_temperatures_.dry_target_temperature.value());
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_DRY));
     this->enqueue_request_(HlinkRequestFrame::with_uint16(
         HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->initial_target_temperatures_.dry_target_temperature.value())));
+        static_cast<uint16_t>(this->stored_target_temperatures_.dry_target_temperature.value())));
   }
-  if (this->initial_target_temperatures_.heat_cool_target_temperature.has_value()) {
+  if (this->stored_target_temperatures_.heat_cool_target_temperature.has_value()) {
     float target =
-        this->clamp_auto_temperature_(this->initial_target_temperatures_.heat_cool_target_temperature.value());
+        this->clamp_auto_temperature_(this->stored_target_temperatures_.heat_cool_target_temperature.value());
     uint16_t encoded = this->encode_auto_temperature_(target);
-    ESP_LOGI(TAG, "Setting initial heat_cool target temperature: %.1f (encoded: %04X)",
-             this->initial_target_temperatures_.heat_cool_target_temperature.value(), encoded);
+    ESP_LOGI(TAG, "Restoring last set heat_cool target temperature: %.1f (encoded: %04X)",
+             this->stored_target_temperatures_.heat_cool_target_temperature.value(), encoded);
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_AUTO));
     this->enqueue_request_(

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -264,7 +264,7 @@ void HlinkAc::loop() {
     };
     boot_definition.on_timeout = []() { return INIT; };
     this->start_poll_cycle_(std::move(boot_definition));
-    // Continue to the REQUEST_NEXT_STATUS_FEATURE block below to send the first request right away
+    return;
   }
 
   if (this->status_.state == REQUEST_NEXT_STATUS_FEATURE && this->can_send_next_frame_()) {

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -226,8 +226,19 @@ bool HlinkAc::can_start_next_polling_() const {
 
 void HlinkAc::request_status_update_() {
   if (this->status_.state == IDLE) {
-    // Launch a full polling cycle over all configured features
-    this->start_poll_cycle_({this->status_.polling_features, nullptr, nullptr});
+    // Launch a full polling cycle over all configured features. Completing or failing the cycle re-arms the status
+    // update interval, allowing the IDLE block to start the next polling cycle on time.
+    PollCycleDefinition def{};
+    def.features = this->status_.polling_features;
+    def.on_completed = [this]() {
+      this->refresh_status_polling_finished_at_();
+      return PUBLISH_UPDATE_IF_ANY;
+    };
+    def.on_failure = [this]() {
+      this->refresh_status_polling_finished_at_();
+      return IDLE;
+    };
+    this->start_poll_cycle_(std::move(def));
   }
 }
 
@@ -260,9 +271,13 @@ void HlinkAc::loop() {
     boot_definition.features = {this->make_power_state_request_(), this->make_mode_request_(),
                                 this->make_target_temp_request_(), this->make_current_temp_request_()};
     boot_definition.on_completed = [this]() {
+      this->refresh_status_polling_finished_at_();
       return this->hlink_entity_status_.has_minimal_hvac_status() ? RESTORE_TARGET_TEMPERATURES : INIT;
     };
-    boot_definition.on_timeout = []() { return INIT; };
+    boot_definition.on_failure = [this]() {
+      this->refresh_status_polling_finished_at_();
+      return INIT;
+    };
     this->start_poll_cycle_(std::move(boot_definition));
     return;
   }
@@ -284,19 +299,23 @@ void HlinkAc::loop() {
     }
     HlinkRequest requested_feature = *this->status_.current_request;
     if (this->handle_hlink_request_response_(requested_feature, response)) {
+      if (response.status != HlinkResponseFrame::Status::OK) {
+        this->status_.polling_cycle.mark_feature_failure();
+      }
       if (this->status_.polling_cycle.has_more_features()) {
         this->status_.polling_cycle.advance();
         this->status_.state = REQUEST_NEXT_STATUS_FEATURE;
       } else {
         this->status_.state = POLL_DONE;
-        this->status_.last_status_polling_finished_at_ms = this->current_time_ms();
       }
       this->status_.current_request = nullptr;
     }
   }
 
   if (this->status_.state == POLL_DONE) {
-    HlinkComponentState next_state = this->status_.polling_cycle.dispatch_completion();
+    HlinkComponentState next_state = this->status_.polling_cycle.has_feature_failure()
+                                         ? this->status_.polling_cycle.dispatch_failure()
+                                         : this->status_.polling_cycle.dispatch_completion();
     this->status_.polling_cycle.clear();
     this->status_.state = next_state;
     return;
@@ -398,7 +417,7 @@ void HlinkAc::loop() {
       this->pending_action_requests_.dequeue();
     }
     HlinkComponentState next_state =
-        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.dispatch_timeout() : IDLE;
+        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.dispatch_failure() : IDLE;
     this->status_.reset_state();
     this->status_.state = next_state;
   }
@@ -429,7 +448,7 @@ void HlinkAc::loop() {
     PollCycleDefinition low_priority_definition{};
     low_priority_definition.features.push_back(this->status_.low_priority_hlink_request.value());
     low_priority_definition.on_completed = []() { return IDLE; };
-    low_priority_definition.on_timeout = []() { return IDLE; };
+    low_priority_definition.on_failure = []() { return IDLE; };
     this->status_.low_priority_hlink_request = {};
     this->start_poll_cycle_(std::move(low_priority_definition));
   }

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -772,7 +772,12 @@ void HlinkAc::control(const esphome::climate::ClimateCall &call) {
                              }
                              this->publish_state();
                            });
-    if (power_state && this->remember_target_temperatures_ && !this->hlink_entity_status_.power_state.value_or(false) &&
+    // The AC may resume an unexpected state (e.g. its last remembered one or a factory default) when it is turned on
+    // or switched to another mode, so fill in the last remembered target temperature when the call doesn't specify
+    // one. Re-selecting the mode the AC is already running in is skipped.
+    if (power_state && this->remember_target_temperatures_ &&
+        (!this->hlink_entity_status_.power_state.value_or(false) ||
+         this->hlink_entity_status_.mode.value_or(esphome::climate::ClimateMode::CLIMATE_MODE_OFF) != mode) &&
         !call.get_target_temperature().has_value() &&
         call.get_preset() != climate::ClimatePreset::CLIMATE_PRESET_AWAY) {
       this->enqueue_remembered_target_temperature_(mode);

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -251,19 +251,18 @@ void HlinkAc::start_poll_cycle_(PollCycleDefinition def) {
 /*
  * Main loop implements a state machine with the following states:
  * 1. INIT - starts a minimal polling cycle (power, mode, target and current temperature) on first boot. The cycle is
- *    retried until a minimal status is received, then the component transitions to RESTORE_TARGET_TEMPERATURES.
+ *    retried until a minimal status is received, then the component transitions to PUBLISH_UPDATE_IF_ANY.
  * 2. IDLE - does nothing.
  * 3. REQUEST_NEXT_STATUS_FEATURE - sends a request for the next feature of the current polling cycle; the cycle
  *    definition is stored in the polling_cycle.
  * 4. READ_FEATURE_RESPONSE - reads a response for the requested hlink feature.
  * 5. POLL_DONE - all features of the current polling cycle were polled; runs the cycle completion hook which decides
  *    the next state.
- * 6. RESTORE_TARGET_TEMPERATURES - restores the stored target temperatures if the AC is off; boot transition state.
- * 7. PUBLISH_UPDATE_IF_ANY - once all features are read, updates components if there are any changes.
- * 8. CAPTURE_TARGET_TEMPERATURE - stores the last seen target temperature per mode if the corresponding option is
+ * 6. PUBLISH_UPDATE_IF_ANY - once all features are read, updates components if there are any changes.
+ * 7. CAPTURE_TARGET_TEMPERATURE - stores the last seen target temperature per mode if the corresponding option is
  *    enabled.
- * 9. APPLY_REQUEST - applies the requested climate controls from the queue.
- * 10. ACK_APPLIED_REQUEST - confirms successfully applied control request.
+ * 8. APPLY_REQUEST - applies the requested climate controls from the queue.
+ * 9. ACK_APPLIED_REQUEST - confirms successfully applied control request.
  */
 void HlinkAc::loop() {
   if (this->status_.state == INIT && this->can_send_next_frame_()) {
@@ -272,7 +271,7 @@ void HlinkAc::loop() {
                                 this->make_target_temp_request_(), this->make_current_temp_request_()};
     boot_definition.on_completed = [this]() {
       this->refresh_status_polling_finished_at_();
-      return this->hlink_entity_status_.has_minimal_hvac_status() ? RESTORE_TARGET_TEMPERATURES : INIT;
+      return this->hlink_entity_status_.has_minimal_hvac_status() ? PUBLISH_UPDATE_IF_ANY : INIT;
     };
     boot_definition.on_failure = [this]() {
       this->refresh_status_polling_finished_at_();
@@ -318,12 +317,6 @@ void HlinkAc::loop() {
                                          : this->status_.polling_cycle.dispatch_completion();
     this->status_.polling_cycle.clear();
     this->status_.state = next_state;
-    return;
-  }
-
-  if (this->status_.state == RESTORE_TARGET_TEMPERATURES) {
-    this->apply_restored_target_temperatures_if_needed_();
-    this->status_.state = PUBLISH_UPDATE_IF_ANY;
     return;
   }
 
@@ -375,15 +368,14 @@ void HlinkAc::loop() {
   // Reset status if we reached timeout deadline
   if (this->status_.state != IDLE && this->reached_timeout_threshold_()) {
     ESP_LOGW(TAG, "Reached global timeout threshold while performing [%s] state action.",
-             this->status_.state == REQUEST_NEXT_STATUS_FEATURE   ? "REQUEST_NEXT_STATUS_FEATURE"
-             : this->status_.state == READ_FEATURE_RESPONSE       ? "READ_FEATURE_RESPONSE"
-             : this->status_.state == POLL_DONE                   ? "POLL_DONE"
-             : this->status_.state == RESTORE_TARGET_TEMPERATURES ? "RESTORE_TARGET_TEMPERATURES"
-             : this->status_.state == PUBLISH_UPDATE_IF_ANY       ? "PUBLISH_UPDATE_IF_ANY"
-             : this->status_.state == CAPTURE_TARGET_TEMPERATURE  ? "CAPTURE_TARGET_TEMPERATURE"
-             : this->status_.state == APPLY_REQUEST               ? "APPLY_REQUEST"
-             : this->status_.state == ACK_APPLIED_REQUEST         ? "ACK_APPLIED_REQUEST"
-                                                                  : "UNKNOWN");
+             this->status_.state == REQUEST_NEXT_STATUS_FEATURE  ? "REQUEST_NEXT_STATUS_FEATURE"
+             : this->status_.state == READ_FEATURE_RESPONSE      ? "READ_FEATURE_RESPONSE"
+             : this->status_.state == POLL_DONE                  ? "POLL_DONE"
+             : this->status_.state == PUBLISH_UPDATE_IF_ANY      ? "PUBLISH_UPDATE_IF_ANY"
+             : this->status_.state == CAPTURE_TARGET_TEMPERATURE ? "CAPTURE_TARGET_TEMPERATURE"
+             : this->status_.state == APPLY_REQUEST              ? "APPLY_REQUEST"
+             : this->status_.state == ACK_APPLIED_REQUEST        ? "ACK_APPLIED_REQUEST"
+                                                                 : "UNKNOWN");
     ESP_LOGW(
         TAG,
         "Component state: polling_cycle_active=%s, polling_cycle_index=%d, non_idle_timeout_limit_ms=%lu, "
@@ -780,6 +772,11 @@ void HlinkAc::control(const esphome::climate::ClimateCall &call) {
                              }
                              this->publish_state();
                            });
+    if (power_state && this->remember_target_temperatures_ && !this->hlink_entity_status_.power_state.value_or(false) &&
+        !call.get_target_temperature().has_value() &&
+        call.get_preset() != climate::ClimatePreset::CLIMATE_PRESET_AWAY) {
+      this->enqueue_remembered_target_temperature_(mode);
+    }
   }
   if (call.get_fan_mode().has_value()) {
     climate::ClimateFanMode fan_mode = *call.get_fan_mode();
@@ -1194,23 +1191,9 @@ void HlinkAc::capture_target_temperature_(climate::ClimateMode mode, float tempe
   if (!this->remember_target_temperatures_) {
     return;
   }
-  optional<float> *target_temperature = nullptr;
-  switch (mode) {
-    case climate::ClimateMode::CLIMATE_MODE_HEAT:
-      target_temperature = &this->stored_target_temperatures_.heat_target_temperature;
-      break;
-    case climate::ClimateMode::CLIMATE_MODE_COOL:
-      target_temperature = &this->stored_target_temperatures_.cool_target_temperature;
-      break;
-    case climate::ClimateMode::CLIMATE_MODE_DRY:
-      target_temperature = &this->stored_target_temperatures_.dry_target_temperature;
-      break;
-    case climate::ClimateMode::CLIMATE_MODE_HEAT_COOL:
-      target_temperature = &this->stored_target_temperatures_.heat_cool_target_temperature;
-      break;
-    default:
-      // OFF and FAN_ONLY modes don't have a target temperature.
-      return;
+  optional<float> *target_temperature = this->stored_target_temperature_for_(mode);
+  if (target_temperature == nullptr) {
+    return;
   }
   if (target_temperature->has_value() && this->is_nanable_equal_(target_temperature->value(), temperature)) {
     return;
@@ -1223,16 +1206,50 @@ void HlinkAc::capture_target_temperature_from_status_() {
   if (!this->hlink_entity_status_.has_minimal_hvac_status()) {
     return;
   }
+  if (!this->hlink_entity_status_.power_state.value()) {
+    return;
+  }
   if (std::isnan(this->hlink_entity_status_.target_temperature.value())) {
     return;
   }
-  if (this->hlink_entity_status_.mode.value() == climate::ClimateMode::CLIMATE_MODE_HEAT &&
-      this->hlink_entity_status_.target_temperature.value() == PROTOCOL_TARGET_TEMP_MIN) {
+  const climate::ClimateMode mode = this->hlink_entity_status_.mode.value();
+  const float reported_target_temperature = this->hlink_entity_status_.target_temperature.value();
+  if (mode == climate::ClimateMode::CLIMATE_MODE_HEAT && reported_target_temperature == PROTOCOL_TARGET_TEMP_MIN) {
     // Away (leave home) mode uses target temperature 10 as a marker, don't remember it.
     return;
   }
-  this->capture_target_temperature_(this->hlink_entity_status_.mode.value(),
-                                    this->hlink_entity_status_.target_temperature.value());
+  this->capture_target_temperature_(mode, reported_target_temperature);
+}
+
+optional<float> *HlinkAc::stored_target_temperature_for_(climate::ClimateMode mode) {
+  switch (mode) {
+    case climate::ClimateMode::CLIMATE_MODE_HEAT:
+      return &this->stored_target_temperatures_.heat_target_temperature;
+    case climate::ClimateMode::CLIMATE_MODE_COOL:
+      return &this->stored_target_temperatures_.cool_target_temperature;
+    case climate::ClimateMode::CLIMATE_MODE_DRY:
+      return &this->stored_target_temperatures_.dry_target_temperature;
+    case climate::ClimateMode::CLIMATE_MODE_HEAT_COOL:
+      return &this->stored_target_temperatures_.heat_cool_target_temperature;
+    default:
+      // OFF and FAN_ONLY modes don't have a target temperature.
+      return nullptr;
+  }
+}
+
+void HlinkAc::enqueue_remembered_target_temperature_(climate::ClimateMode mode) {
+  const optional<float> *stored_target_temperature = this->stored_target_temperature_for_(mode);
+  if (stored_target_temperature == nullptr || !stored_target_temperature->has_value()) {
+    return;
+  }
+  float target_temperature = stored_target_temperature->value();
+  uint16_t hlink_target_temperature = static_cast<uint16_t>(target_temperature);
+  if (mode == climate::ClimateMode::CLIMATE_MODE_HEAT_COOL) {
+    target_temperature = this->clamp_auto_temperature_(target_temperature);
+    hlink_target_temperature = this->encode_auto_temperature_(target_temperature);
+  }
+  this->enqueue_request_(
+      HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP, hlink_target_temperature));
 }
 
 optional<float> HlinkAc::restore_target_temperature_(float value, float min_temperature, float max_temperature) const {
@@ -1245,56 +1262,6 @@ optional<float> HlinkAc::restore_target_temperature_(float value, float min_temp
     return {};
   }
   return value;
-}
-
-void HlinkAc::apply_stored_target_temperatures_() {
-  if (!this->remember_target_temperatures_) {
-    return;
-  }
-  if (this->stored_target_temperatures_.heat_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Restoring last set heat target temperature: %.1f",
-             this->stored_target_temperatures_.heat_target_temperature.value());
-    this->enqueue_request_(
-        HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_HEAT));
-    this->enqueue_request_(HlinkRequestFrame::with_uint16(
-        HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->stored_target_temperatures_.heat_target_temperature.value())));
-  }
-  if (this->stored_target_temperatures_.cool_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Restoring last set cool target temperature: %.1f",
-             this->stored_target_temperatures_.cool_target_temperature.value());
-    this->enqueue_request_(
-        HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_COOL));
-    this->enqueue_request_(HlinkRequestFrame::with_uint16(
-        HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->stored_target_temperatures_.cool_target_temperature.value())));
-  }
-  if (this->stored_target_temperatures_.dry_target_temperature.has_value()) {
-    ESP_LOGI(TAG, "Restoring last set dry target temperature: %.1f",
-             this->stored_target_temperatures_.dry_target_temperature.value());
-    this->enqueue_request_(
-        HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_DRY));
-    this->enqueue_request_(HlinkRequestFrame::with_uint16(
-        HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP,
-        static_cast<uint16_t>(this->stored_target_temperatures_.dry_target_temperature.value())));
-  }
-  if (this->stored_target_temperatures_.heat_cool_target_temperature.has_value()) {
-    float target =
-        this->clamp_auto_temperature_(this->stored_target_temperatures_.heat_cool_target_temperature.value());
-    uint16_t encoded = this->encode_auto_temperature_(target);
-    ESP_LOGI(TAG, "Restoring last set heat_cool target temperature: %.1f (encoded: %04X)",
-             this->stored_target_temperatures_.heat_cool_target_temperature.value(), encoded);
-    this->enqueue_request_(
-        HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::MODE, HLINK_MODE_AUTO));
-    this->enqueue_request_(
-        HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP, encoded));
-  }
-}
-
-void HlinkAc::apply_restored_target_temperatures_if_needed_() {
-  if (this->hlink_entity_status_.power_state.has_value() && !this->hlink_entity_status_.power_state.value()) {
-    this->apply_stored_target_temperatures_();
-  }
 }
 
 std::string HlinkAc::format_target_temperature_log_(optional<float> target_temperature, bool show_auto_offset) const {

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -773,7 +773,6 @@ void HlinkAc::control(const esphome::climate::ClimateCall &call) {
       target_temperature = this->clamp_auto_temperature_(target_temperature);
       hlink_target_temperature = this->encode_auto_temperature_(target_temperature);
     }
-    this->capture_target_temperature_(requested_mode, target_temperature);
     this->enqueue_request_(
         HlinkRequestFrame::with_uint16(HlinkRequestFrame::Type::ST, FeatureType::TARGET_TEMP, hlink_target_temperature),
         [this, target_temperature](const HlinkResponseFrame &response) {

--- a/components/hlink_ac/hlink_ac.cpp
+++ b/components/hlink_ac/hlink_ac.cpp
@@ -227,7 +227,7 @@ bool HlinkAc::can_start_next_polling_() const {
 void HlinkAc::request_status_update_() {
   if (this->status_.state == IDLE) {
     // Launch a full polling cycle over all configured features
-    this->start_poll_cycle_({this->status_.polling_features, nullptr, IDLE});
+    this->start_poll_cycle_({this->status_.polling_features, nullptr, nullptr});
   }
 }
 
@@ -262,7 +262,7 @@ void HlinkAc::loop() {
     boot_definition.on_completed = [this]() {
       return this->hlink_entity_status_.has_minimal_hvac_status() ? RESTORE_TARGET_TEMPERATURES : INIT;
     };
-    boot_definition.next_state_on_timeout = INIT;
+    boot_definition.on_timeout = []() { return INIT; };
     this->start_poll_cycle_(std::move(boot_definition));
     // Continue to the REQUEST_NEXT_STATUS_FEATURE block below to send the first request right away
   }
@@ -398,7 +398,7 @@ void HlinkAc::loop() {
       this->pending_action_requests_.dequeue();
     }
     HlinkComponentState next_state =
-        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.next_state_on_timeout() : IDLE;
+        this->status_.polling_cycle.is_active() ? this->status_.polling_cycle.dispatch_timeout() : IDLE;
     this->status_.reset_state();
     this->status_.state = next_state;
   }
@@ -429,7 +429,7 @@ void HlinkAc::loop() {
     PollCycleDefinition low_priority_definition{};
     low_priority_definition.features.push_back(this->status_.low_priority_hlink_request.value());
     low_priority_definition.on_completed = []() { return IDLE; };
-    low_priority_definition.next_state_on_timeout = IDLE;
+    low_priority_definition.on_timeout = []() { return IDLE; };
     this->status_.low_priority_hlink_request = {};
     this->start_poll_cycle_(std::move(low_priority_definition));
   }

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -253,7 +253,7 @@ enum class TextSensorType {
 };
 #endif
 
-struct InitialTargetTemperatures {
+struct StoredTargetTemperatures {
   optional<float> heat_target_temperature;
   optional<float> cool_target_temperature;
   optional<float> heat_cool_target_temperature;
@@ -262,8 +262,11 @@ struct InitialTargetTemperatures {
 
 struct HlinkAcSettings {
   bool beeper_enabled;
-  // Preserve the preference layout from releases that stored a second settings byte.
-  uint8_t reserved;
+  // Last user-set target temperatures per mode. NAN means the temperature was never set.
+  float heat_target_temperature;
+  float cool_target_temperature;
+  float heat_cool_target_temperature;
+  float dry_target_temperature;
 };
 
 static const uint8_t REQUESTS_QUEUE_SIZE = 16;
@@ -340,7 +343,7 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   void reset_air_filter_clean_warning();
   void set_status_update_interval(uint32_t interval_ms);
   void set_reference_temperature(float reference_temperature);
-  void set_initial_target_temperatures(const InitialTargetTemperatures &config);
+  void set_remember_target_temperatures(bool remember);
   void send_hlink_cmd(std::string cmd_type, std::string address, optional<std::string> data);
   void add_send_hlink_cmd_result_callback(std::function<void(const SendHlinkCmdResult &)> &&callback);
 
@@ -349,7 +352,8 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   HlinkEntityStatus hlink_entity_status_ = HlinkEntityStatus();
   climate::ClimateTraits traits_ = climate::ClimateTraits();
   float reference_temperature_{25.0f};
-  InitialTargetTemperatures initial_target_temperatures_;
+  bool remember_target_temperatures_{false};
+  StoredTargetTemperatures stored_target_temperatures_;
   CircularRequestsQueue pending_action_requests_;
   ESPPreferenceObject rtc_;
   CallbackManager<void(const SendHlinkCmdResult &)> send_hlink_cmd_result_callback_{};
@@ -361,7 +365,9 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   void request_status_update_();
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);
   void publish_updates_if_any_();
-  void apply_initial_target_temperatures_();
+  void apply_stored_target_temperatures_();
+  void capture_target_temperature_(esphome::climate::ClimateMode mode, float temperature);
+  optional<float> restore_target_temperature_(float value, float min_temperature, float max_temperature) const;
   HlinkResponseFrame read_hlink_frame_();
   void write_hlink_frame_(HlinkRequestFrame frame);
   void enqueue_request_(HlinkRequestFrame request_frame,

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -425,11 +425,17 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   HlinkRequest make_swing_mode_request_();
   HlinkRequest make_leave_home_request_();
   HlinkRequest make_activity_status_request_();
+#ifdef USE_SWITCH
   HlinkRequest make_remote_control_lock_request_();
+#endif
+#ifdef USE_SENSOR
   HlinkRequest make_current_outdoor_temp_request_();
+#endif
+#ifdef USE_BINARY_SENSOR
   HlinkRequest make_air_filter_warning_request_();
-  HlinkRequest make_model_name_request_();
+#endif
 #ifdef USE_TEXT_SENSOR
+  HlinkRequest make_model_name_request_();
   HlinkRequest make_debug_request_(uint16_t address, text_sensor::TextSensor *sens);
 #endif
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -197,7 +197,8 @@ struct PollCycleDefinition {
   std::vector<HlinkRequest> features;
   // Invoked when all features of the cycle have been polled successfully.
   std::function<HlinkComponentState()> on_completed = {};
-  HlinkComponentState next_state_on_timeout = IDLE;
+  // Invoked when the polling cycle hits the timeout deadline.
+  std::function<HlinkComponentState()> on_timeout = {};
 };
 
 // Run state and lifecycle of a single polling cycle.
@@ -233,7 +234,7 @@ class PollingCycle {
     return this->def_.on_completed ? this->def_.on_completed() : PUBLISH_UPDATE_IF_ANY;
   }
 
-  HlinkComponentState next_state_on_timeout() const { return this->def_.next_state_on_timeout; }
+  HlinkComponentState dispatch_timeout() const { return this->def_.on_timeout ? this->def_.on_timeout() : IDLE; }
 
   uint32_t timeout_ms() const { return this->def_.features.size() * 500; }
 

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -452,7 +452,6 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   void enqueue_remembered_target_temperature_(esphome::climate::ClimateMode mode);
   optional<float> *stored_target_temperature_for_(esphome::climate::ClimateMode mode);
   void capture_target_temperature_from_status_();
-  void capture_target_temperature_(esphome::climate::ClimateMode mode, float temperature);
   optional<float> restore_target_temperature_(float value, float min_temperature, float max_temperature) const;
   HlinkResponseFrame read_hlink_frame_();
   void write_hlink_frame_(HlinkRequestFrame frame);

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -429,7 +429,9 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   HlinkRequest make_current_outdoor_temp_request_();
   HlinkRequest make_air_filter_warning_request_();
   HlinkRequest make_model_name_request_();
+#ifdef USE_TEXT_SENSOR
   HlinkRequest make_debug_request_(uint16_t address, text_sensor::TextSensor *sens);
+#endif
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);
   void publish_updates_if_any_();
   void apply_stored_target_temperatures_();

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -197,8 +197,8 @@ struct PollCycleDefinition {
   std::vector<HlinkRequest> features;
   // Invoked when all features of the cycle have been polled successfully.
   std::function<HlinkComponentState()> on_completed = {};
-  // Invoked when the polling cycle hits the timeout deadline.
-  std::function<HlinkComponentState()> on_timeout = {};
+  // Invoked when the polling cycle cannot be completed (timeout or a failed feature).
+  std::function<HlinkComponentState()> on_failure = {};
 };
 
 // Run state and lifecycle of a single polling cycle.
@@ -207,12 +207,14 @@ class PollingCycle {
   void start(PollCycleDefinition def) {
     this->def_ = std::move(def);
     this->requested_feature_index_ = 0;
+    this->feature_failure_ = false;
     this->active_ = true;
   }
 
   void clear() {
     this->active_ = false;
     this->requested_feature_index_ = 0;
+    this->feature_failure_ = false;
     this->def_ = {};
   }
 
@@ -226,11 +228,15 @@ class PollingCycle {
 
   void advance() { this->requested_feature_index_++; }
 
+  void mark_feature_failure() { this->feature_failure_ = true; }
+
+  bool has_feature_failure() const { return this->feature_failure_; }
+
   HlinkComponentState dispatch_completion() const {
     return this->def_.on_completed ? this->def_.on_completed() : PUBLISH_UPDATE_IF_ANY;
   }
 
-  HlinkComponentState dispatch_timeout() const { return this->def_.on_timeout ? this->def_.on_timeout() : IDLE; }
+  HlinkComponentState dispatch_failure() const { return this->def_.on_failure ? this->def_.on_failure() : IDLE; }
 
   uint32_t timeout_ms() const { return this->def_.features.size() * 500; }
 
@@ -239,6 +245,7 @@ class PollingCycle {
  private:
   bool active_{false};
   uint16_t requested_feature_index_{0};
+  bool feature_failure_{false};
   PollCycleDefinition def_;
 };
 
@@ -412,6 +419,9 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   CallbackManager<void(const SendHlinkCmdResult &)> send_hlink_cmd_result_callback_{};
   virtual uint32_t current_time_ms() const { return millis(); }
   void refresh_non_idle_timeout_(uint32_t non_idle_timeout_limit_ms);
+  void refresh_status_polling_finished_at_() {
+    this->status_.last_status_polling_finished_at_ms = this->current_time_ms();
+  }
   bool reached_timeout_threshold_() const;
   bool can_send_next_frame_() const;
   bool can_start_next_polling_() const;

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -44,6 +44,7 @@ enum HlinkComponentState : uint8_t {
   REQUEST_LOW_PRIORITY_FEATURE,
   READ_FEATURE_RESPONSE,
   PUBLISH_UPDATE_IF_ANY,
+  CAPTURE_TARGET_TEMPERATURE,
   APPLY_REQUEST,
   ACK_APPLIED_REQUEST
 };
@@ -366,6 +367,7 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);
   void publish_updates_if_any_();
   void apply_stored_target_temperatures_();
+  void capture_target_temperature_from_status_();
   void capture_target_temperature_(esphome::climate::ClimateMode mode, float temperature);
   optional<float> restore_target_temperature_(float value, float min_temperature, float max_temperature) const;
   HlinkResponseFrame read_hlink_frame_();
@@ -397,7 +399,7 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
     return static_cast<uint16_t>(static_cast<uint8_t>(offset)) + 0xFF00;
   }
   std::string format_target_temperature_log_(optional<float> target_temperature, bool show_auto_offset) const;
-  void save_settings_();
+  virtual void save_settings_();
 };
 }  // namespace hlink_ac
 }  // namespace esphome

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -205,7 +205,6 @@ struct PollCycleDefinition {
 class PollingCycle {
  public:
   void start(PollCycleDefinition def) {
-    assert(!def.features.empty());
     this->def_ = std::move(def);
     this->requested_feature_index_ = 0;
     this->active_ = true;
@@ -219,10 +218,7 @@ class PollingCycle {
 
   bool is_active() const { return this->active_; }
 
-  const HlinkRequest &current_request() const {
-    assert(this->active_);
-    return this->def_.features[this->requested_feature_index_];
-  }
+  const HlinkRequest &current_request() const { return this->def_.features[this->requested_feature_index_]; }
 
   bool has_more_features() const {
     return this->active_ && this->requested_feature_index_ + 1 < this->def_.features.size();

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -41,8 +41,9 @@ enum HlinkComponentState : uint8_t {
   INIT,
   IDLE,
   REQUEST_NEXT_STATUS_FEATURE,
-  REQUEST_LOW_PRIORITY_FEATURE,
   READ_FEATURE_RESPONSE,
+  POLL_DONE,
+  RESTORE_TARGET_TEMPERATURES,
   PUBLISH_UPDATE_IF_ANY,
   CAPTURE_TARGET_TEMPERATURE,
   APPLY_REQUEST,
@@ -192,6 +193,58 @@ struct HlinkRequest {
   std::function<void()> timeout_callback;
 };
 
+struct PollCycleDefinition {
+  std::vector<HlinkRequest> features;
+  // Invoked when all features of the cycle have been polled successfully.
+  std::function<HlinkComponentState()> on_completed = {};
+  HlinkComponentState next_state_on_timeout = IDLE;
+};
+
+// Run state and lifecycle of a single polling cycle.
+class PollingCycle {
+ public:
+  void start(PollCycleDefinition def) {
+    assert(!def.features.empty());
+    this->def_ = std::move(def);
+    this->requested_feature_index_ = 0;
+    this->active_ = true;
+  }
+
+  void clear() {
+    this->active_ = false;
+    this->requested_feature_index_ = 0;
+    this->def_ = {};
+  }
+
+  bool is_active() const { return this->active_; }
+
+  const HlinkRequest &current_request() const {
+    assert(this->active_);
+    return this->def_.features[this->requested_feature_index_];
+  }
+
+  bool has_more_features() const {
+    return this->active_ && this->requested_feature_index_ + 1 < this->def_.features.size();
+  }
+
+  void advance() { this->requested_feature_index_++; }
+
+  HlinkComponentState dispatch_completion() const {
+    return this->def_.on_completed ? this->def_.on_completed() : PUBLISH_UPDATE_IF_ANY;
+  }
+
+  HlinkComponentState next_state_on_timeout() const { return this->def_.next_state_on_timeout; }
+
+  uint32_t timeout_ms() const { return this->def_.features.size() * 500; }
+
+  int get_requested_feature_index_for_debug() const { return this->requested_feature_index_; }
+
+ private:
+  bool active_{false};
+  uint16_t requested_feature_index_{0};
+  PollCycleDefinition def_;
+};
+
 struct ComponentStatus {
   HlinkComponentState state = IDLE;
   std::string hlink_response_buffer = std::string(HLINK_MSG_READ_BUFFER_SIZE, '\0');
@@ -199,7 +252,7 @@ struct ComponentStatus {
   std::unique_ptr<HlinkRequest> current_request = nullptr;
   std::vector<HlinkRequest> polling_features = {};
   optional<HlinkRequest> low_priority_hlink_request = {};
-  int16_t requested_feature_index = -1;
+  PollingCycle polling_cycle;
   uint32_t status_update_interval_ms = DEFAULT_STATUS_UPDATE_INTERVAL;
   uint32_t non_idle_timeout_limit_ms = 0;
   uint32_t last_status_polling_finished_at_ms = 0;
@@ -207,16 +260,14 @@ struct ComponentStatus {
   uint32_t timeout_counter_started_at_ms = 0;
   uint8_t requests_left_to_apply = 0;
 
-  HlinkRequest get_currently_polling_feature() { return polling_features[requested_feature_index]; }
-
   void reset_state() {
     state = IDLE;
     timeout_counter_started_at_ms = 0;
     non_idle_timeout_limit_ms = 0;
     last_status_polling_finished_at_ms = 0;
-    requested_feature_index = -1;
     requests_left_to_apply = 0;
     current_request = nullptr;
+    polling_cycle.clear();
   }
 
   void reset_response_buffer() {
@@ -305,10 +356,14 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
  protected:
   void update_sensor_state_(sensor::Sensor *sensor, float value);
   sensor::Sensor *indoor_temperature_sensor_{nullptr};
+  sensor::Sensor *outdoor_temperature_sensor_{nullptr};
 #endif
 #ifdef USE_BINARY_SENSOR
  public:
   void set_binary_sensor(BinarySensorType type, binary_sensor::BinarySensor *s);
+
+ protected:
+  binary_sensor::BinarySensor *air_filter_warning_sensor_{nullptr};
 #endif
 #ifdef USE_TEXT_SENSOR
  public:
@@ -364,9 +419,24 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
   bool can_send_next_frame_() const;
   bool can_start_next_polling_() const;
   void request_status_update_();
+  void start_poll_cycle_(PollCycleDefinition def);
+  HlinkRequest make_power_state_request_();
+  HlinkRequest make_mode_request_();
+  HlinkRequest make_target_temp_request_();
+  HlinkRequest make_current_temp_request_();
+  HlinkRequest make_fan_mode_request_();
+  HlinkRequest make_swing_mode_request_();
+  HlinkRequest make_leave_home_request_();
+  HlinkRequest make_activity_status_request_();
+  HlinkRequest make_remote_control_lock_request_();
+  HlinkRequest make_current_outdoor_temp_request_();
+  HlinkRequest make_air_filter_warning_request_();
+  HlinkRequest make_model_name_request_();
+  HlinkRequest make_debug_request_(uint16_t address, text_sensor::TextSensor *sens);
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);
   void publish_updates_if_any_();
   void apply_stored_target_temperatures_();
+  void apply_restored_target_temperatures_if_needed_();
   void capture_target_temperature_from_status_();
   void capture_target_temperature_(esphome::climate::ClimateMode mode, float temperature);
   optional<float> restore_target_temperature_(float value, float min_temperature, float max_temperature) const;

--- a/components/hlink_ac/hlink_ac.h
+++ b/components/hlink_ac/hlink_ac.h
@@ -43,7 +43,6 @@ enum HlinkComponentState : uint8_t {
   REQUEST_NEXT_STATUS_FEATURE,
   READ_FEATURE_RESPONSE,
   POLL_DONE,
-  RESTORE_TARGET_TEMPERATURES,
   PUBLISH_UPDATE_IF_ANY,
   CAPTURE_TARGET_TEMPERATURE,
   APPLY_REQUEST,
@@ -450,8 +449,8 @@ class HlinkAc : public Component, public uart::UARTDevice, public climate::Clima
 #endif
   bool handle_hlink_request_response_(const HlinkRequest &request, const HlinkResponseFrame &response);
   void publish_updates_if_any_();
-  void apply_stored_target_temperatures_();
-  void apply_restored_target_temperatures_if_needed_();
+  void enqueue_remembered_target_temperature_(esphome::climate::ClimateMode mode);
+  optional<float> *stored_target_temperature_for_(esphome::climate::ClimateMode mode);
   void capture_target_temperature_from_status_();
   void capture_target_temperature_(esphome::climate::ClimateMode mode, float temperature);
   optional<float> restore_target_temperature_(float value, float min_temperature, float max_temperature) const;

--- a/tests/components/hlink_ac/common.h
+++ b/tests/components/hlink_ac/common.h
@@ -109,14 +109,22 @@ class TestHlinkAc : public HlinkAc {
 
   StoredTargetTemperatures stored_target_temperatures_for_test() const { return this->stored_target_temperatures_; }
 
+  int save_settings_call_count_for_test() const { return this->save_settings_call_count_; }
+
   HlinkComponentState state() const { return this->status_.state; }
 
   ComponentStatus &status() { return this->status_; }
 
  protected:
+  void save_settings_() override {
+    this->save_settings_call_count_++;
+    HlinkAc::save_settings_();
+  }
+
   uint32_t current_time_ms() const override { return this->current_time_ms_; }
 
   uint32_t current_time_ms_{1000};
+  int save_settings_call_count_{0};
 };
 
 }  // namespace esphome::hlink_ac::testing

--- a/tests/components/hlink_ac/common.h
+++ b/tests/components/hlink_ac/common.h
@@ -103,6 +103,12 @@ class TestHlinkAc : public HlinkAc {
         HlinkRequest{request_frame, ok_callback, ng_callback, invalid_callback, timeout_callback};
   }
 
+  void set_stored_target_temperatures_for_test(const StoredTargetTemperatures &stored_target_temperatures) {
+    this->stored_target_temperatures_ = stored_target_temperatures;
+  }
+
+  StoredTargetTemperatures stored_target_temperatures_for_test() const { return this->stored_target_temperatures_; }
+
   HlinkComponentState state() const { return this->status_.state; }
 
   ComponentStatus &status() { return this->status_; }

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -150,6 +150,60 @@ TEST_F(HlinkAcStateMachineTest, PollingCycleHappyPath) {
   EXPECT_EQ(this->publish_count_, 1);
 }
 
+TEST_F(HlinkAcStateMachineTest, PollingCycleWithFailedFeatureDoesNotPublishOrCapture) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  ASSERT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
+
+  this->send_poll_request_and_assert("MT P=0000 C=FFFF\r");  // POWER_STATE
+  this->inject_response_and_step("OK P=01 C=FFFE\r");        // POWER_STATE: on
+  this->send_poll_request_and_assert("MT P=0001 C=FFFE\r");  // MODE
+  this->inject_response_and_step("NG P=FFFF C=FFFF\r");      // MODE: NG
+  this->send_poll_request_and_assert("MT P=0003 C=FFFC\r");  // TARGET_TEMP
+  this->inject_response_and_step("OK P=0016 C=FFE9\r");      // TARGET_TEMP: 22°C
+  this->send_poll_request_and_assert("MT P=0100 C=FFFE\r");  // CURRENT_INDOOR_TEMP
+  this->inject_response_and_step("OK P=0018 C=FFE7\r");      // CURRENT_INDOOR_TEMP: 24°C
+  this->send_poll_request_and_assert("MT P=0002 C=FFFD\r");  // FAN_MODE
+  this->inject_response_and_step("OK P=01 C=FFFE\r");        // FAN_MODE: high
+  this->send_poll_request_and_assert("MT P=0900 C=FFF6\r");            // MODEL_NAME
+  this->inject_response_and_step("OK P=52414B2D3235504543 C=FDB5\r");  // MODEL_NAME: "RAK-25PEC"
+
+  EXPECT_EQ(this->ac_.state(), IDLE);
+  EXPECT_EQ(this->publish_count_, 0);
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingCycleWithInvalidResponseDoesNotPublishOrCapture) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  ASSERT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
+
+  this->send_poll_request_and_assert("MT P=0000 C=FFFF\r");  // POWER_STATE
+  this->inject_response_and_step("XX P=0000 C=FFFF\r");      // POWER_STATE: INVALID
+  this->send_poll_request_and_assert("MT P=0001 C=FFFE\r");  // MODE
+  this->inject_response_and_step("OK P=0040 C=FFBF\r");      // MODE: cool
+  this->send_poll_request_and_assert("MT P=0003 C=FFFC\r");  // TARGET_TEMP
+  this->inject_response_and_step("OK P=0016 C=FFE9\r");      // TARGET_TEMP: 22°C
+  this->send_poll_request_and_assert("MT P=0100 C=FFFE\r");  // CURRENT_INDOOR_TEMP
+  this->inject_response_and_step("OK P=0018 C=FFE7\r");      // CURRENT_INDOOR_TEMP: 24°C
+  this->send_poll_request_and_assert("MT P=0002 C=FFFD\r");  // FAN_MODE
+  this->inject_response_and_step("OK P=01 C=FFFE\r");        // FAN_MODE: high
+  this->send_poll_request_and_assert("MT P=0900 C=FFF6\r");            // MODEL_NAME
+  this->inject_response_and_step("OK P=52414B2D3235504543 C=FDB5\r");  // MODEL_NAME: "RAK-25PEC"
+
+  EXPECT_EQ(this->ac_.state(), IDLE);
+  EXPECT_EQ(this->publish_count_, 0);
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
 TEST_F(HlinkAcStateMachineTest, PartialResponseIsCompletedOnNextLoop) {
   this->ac_.request_status_update_for_test();
   this->send_poll_request_and_assert("MT P=0000 C=FFFF\r");  // POWER_STATE
@@ -241,6 +295,26 @@ TEST_F(HlinkAcStateMachineTest, HandlesLowPriorityRequestFromIdle) {
   EXPECT_TRUE(callback_called);
   EXPECT_EQ(payload_string, "52414B2D3235504543");
   EXPECT_EQ(this->publish_count_, 0);
+}
+
+TEST_F(HlinkAcStateMachineTest, LowPriorityCycleDoesNotDelayNextStatusPolling) {
+  this->ac_.set_status_update_interval(1000);
+  this->ac_.set_low_priority_request_for_test({HlinkRequestFrame::Type::MT, {FeatureType::MODEL_NAME}});
+
+  this->ac_.loop();
+  ASSERT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0900 C=FFF6\r");
+  this->inject_response_and_step("OK P=52414B2D3235504543 C=FDB5\r");
+  EXPECT_EQ(this->ac_.state(), IDLE);
+  // A low-priority (discovery) cycle must not re-arm the status polling interval.
+  EXPECT_EQ(this->ac_.status().last_status_polling_finished_at_ms, 0);
+
+  // Status polling still starts as soon as the update interval has elapsed.
+  this->ac_.advance_current_time_ms_for_test(1000);
+  this->ac_.loop();
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
 }
 
 TEST_F(HlinkAcStateMachineTest, InvokesTimeoutCallbackAndResetsState) {
@@ -348,6 +422,41 @@ TEST_F(HlinkAcStateMachineTest, BootPollingRetriesToInitOnIncompleteStatus) {
   this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // boot cycle retry
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+}
+
+TEST_F(HlinkAcStateMachineTest, BootRetryWithFailedPowerReadDoesNotRestoreStoredTemperatures) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  // First boot cycle: the power read succeeds (off), the mode read fails, so the cycle is incomplete.
+  this->run_boot_cycle({"OK P=00 C=FFFF\r", "NG P=FFFF C=FFFF\r", "OK P=0016 C=FFE9\r",
+                        "OK P=0018 C=FFE7\r"});
+  EXPECT_EQ(this->ac_.state(), INIT);
+  EXPECT_EQ(this->publish_count_, 0);
+
+  // Retry: the power read fails again (stale off state is retained), the rest succeeds.
+  this->advance_for_next_send();
+  this->ac_.loop();  // INIT: start the boot cycle
+  this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+  this->inject_response_and_step("NG P=FFFF C=FFFF\r");      // POWER_STATE: NG
+  this->send_poll_request_and_assert("MT P=0001 C=FFFE\r");  // MODE
+  this->inject_response_and_step("OK P=0010 C=FFEF\r");      // MODE: heat (stale off power -> OFF)
+  this->send_poll_request_and_assert("MT P=0003 C=FFFC\r");  // TARGET_TEMP
+  this->inject_response_and_step("OK P=0016 C=FFE9\r");      // TARGET_TEMP: 22°C
+  this->send_poll_request_and_assert("MT P=0100 C=FFFE\r");  // CURRENT_INDOOR_TEMP
+  this->inject_response_and_step("OK P=0018 C=FFE7\r");      // CURRENT_INDOOR_TEMP: 24°C
+
+  // The failed power read must prevent the cycle from completing, so no stored temperatures are restored.
+  EXPECT_EQ(this->ac_.state(), INIT);
+  EXPECT_EQ(this->publish_count_, 0);
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
 }
 
 TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureTargetTemperature) {

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -8,6 +8,7 @@ class HlinkAcStateMachineTest : public ::testing::Test {
   void advance_for_next_send() { this->ac_.advance_current_time_ms_for_test(MIN_INTERVAL_BETWEEN_REQUESTS + 1); }
 
   void SetUp() override {
+    global_preferences->reset();
     this->ac_.set_uart_parent_for_test(&this->uart_);
     this->ac_.set_current_time_ms_for_test(0);
     this->ac_.set_status_update_interval(0xFFFFFF00U);
@@ -199,13 +200,14 @@ TEST_F(HlinkAcStateMachineTest, SetupInitSendsPowerStateRequestAndTransitionsToI
   EXPECT_EQ(this->publish_count_, 0);
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffEnqueuesInitialTargetTemperatures) {
-  InitialTargetTemperatures initial_temps{};
-  initial_temps.cool_target_temperature = 24.0f;
-  this->ac_.set_initial_target_temperatures(initial_temps);
-
+TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAppliesStoredTargetTemperatures) {
+  this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
 
   this->advance_for_next_send();
   this->ac_.loop();
@@ -231,6 +233,110 @@ TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffEnqueuesInitialTargetTemperatu
   this->inject_response_and_step(ACK_OK_FRAME);
   EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
   EXPECT_EQ(this->publish_count_, 0);
+}
+
+TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndNoStoredTargetTemperaturesDoesNothing) {
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+
+  this->inject_response_and_step("OK P=00 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), IDLE);
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+  EXPECT_EQ(this->publish_count_, 0);
+}
+
+TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndRememberDisabledDoesNotApplyStoredTargetTemperatures) {
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+
+  this->inject_response_and_step("OK P=00 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), IDLE);
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+  EXPECT_EQ(this->publish_count_, 0);
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlCapturesTargetTemperaturePerMode) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.set_reference_temperature(23);
+  this->ac_.setup();
+
+  auto call = this->ac_.make_call();
+  call.set_mode(climate::ClimateMode::CLIMATE_MODE_COOL).set_target_temperature(24.0f);
+  this->ac_.control(call);
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+
+  // Auto-mode temperature is clamped and stored in the auto range.
+  auto auto_call = this->ac_.make_call();
+  auto_call.set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT_COOL).set_target_temperature(28.0f);
+  this->ac_.control(auto_call);
+
+  stored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.heat_cool_target_temperature.value(), 26.0f);
+  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
+
+  // OFF mode does not capture a target temperature.
+  auto off_call = this->ac_.make_call();
+  off_call.set_mode(climate::ClimateMode::CLIMATE_MODE_OFF).set_target_temperature(22.0f);
+  this->ac_.control(off_call);
+
+  stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureWhenRememberDisabled) {
+  this->ac_.setup();
+
+  auto call = this->ac_.make_call();
+  call.set_mode(climate::ClimateMode::CLIMATE_MODE_COOL).set_target_temperature(24.0f);
+  this->ac_.control(call);
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PersistsTargetTemperaturesAcrossRestarts) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  auto call = this->ac_.make_call();
+  call.set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT).set_target_temperature(26.0f);
+  this->ac_.control(call);
+
+  TestHlinkAc restarted_ac;
+  restarted_ac.set_uart_parent_for_test(&this->uart_);
+  restarted_ac.set_current_time_ms_for_test(0);
+  restarted_ac.setup();
+
+  auto stored_temps = restarted_ac.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.heat_target_temperature.value(), 26.0f);
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
 }
 
 TEST_F(HlinkAcStateMachineTest, SetupInitTimeoutResetsToIdle) {

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -50,7 +50,7 @@ class HlinkAcStateMachineTest : public ::testing::Test {
   }
 
   // Sends the 4 minimal boot cycle requests and feeds them the given responses. The cycle completion
-  // lambda has already run, so the state is RESTORE_TARGET_TEMPERATURES on success or INIT on incomplete status.
+  // lambda has already run, so the state is PUBLISH_UPDATE_IF_ANY on success or INIT on incomplete status.
   void run_boot_cycle(const std::vector<std::string> &responses) {
     ASSERT_EQ(responses.size(), 4U);
     const std::vector<std::string> requests = {
@@ -71,11 +71,10 @@ class HlinkAcStateMachineTest : public ::testing::Test {
     }
   }
 
-  // Runs the boot cycle tail: RESTORE_TARGET_TEMPERATURES -> PUBLISH_UPDATE_IF_ANY -> CAPTURE_TARGET_TEMPERATURE ->
-  // IDLE. Must be called after a successful run_boot_cycle.
+  // Runs the boot cycle tail: PUBLISH_UPDATE_IF_ANY -> CAPTURE_TARGET_TEMPERATURE -> IDLE.
+  // Must be called after a successful run_boot_cycle.
   void finish_boot_cycle_to_idle() {
-    EXPECT_EQ(this->ac_.state(), RESTORE_TARGET_TEMPERATURES);
-    this->ac_.loop();  // RESTORE_TARGET_TEMPERATURES
+    EXPECT_EQ(this->ac_.state(), PUBLISH_UPDATE_IF_ANY);
     this->ac_.loop();  // PUBLISH_UPDATE_IF_ANY
     this->ac_.loop();  // CAPTURE_TARGET_TEMPERATURE
     EXPECT_EQ(this->ac_.state(), IDLE);
@@ -345,64 +344,7 @@ TEST_F(HlinkAcStateMachineTest, BootPollingCycleSendsOnlyMinimalRequestsAndTrans
   ASSERT_EQ(this->ac_.state(), INIT);
 
   this->run_boot_cycle(this->boot_cool_cycle_responses_);
-  EXPECT_EQ(this->ac_.state(), RESTORE_TARGET_TEMPERATURES);
-  this->finish_boot_cycle_to_idle();
-  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
-  EXPECT_EQ(this->publish_count_, 1);
-}
-
-TEST_F(HlinkAcStateMachineTest, RestoresTargetTemperaturesAfterFirstSuccessfulBootPoll) {
-  this->ac_.set_remember_target_temperatures(true);
-  this->ac_.setup();
-  ASSERT_EQ(this->ac_.state(), INIT);
-
-  StoredTargetTemperatures stored_temps{};
-  stored_temps.cool_target_temperature = 24.0f;
-  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
-
-  this->run_boot_cycle(this->boot_off_cycle_responses_);
-  this->finish_boot_cycle_to_idle();
-
-  this->ac_.loop();  // pending restore requests -> APPLY_REQUEST
-  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
-
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");
-  EXPECT_EQ(this->ac_.state(), ACK_APPLIED_REQUEST);
-
-  this->inject_response_and_step(ACK_OK_FRAME);
-  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
-
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0018 C=FFE4\r");
-  EXPECT_EQ(this->ac_.state(), ACK_APPLIED_REQUEST);
-
-  this->inject_response_and_step(ACK_OK_FRAME);
-  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
-  EXPECT_EQ(this->publish_count_, 1);
-}
-
-TEST_F(HlinkAcStateMachineTest, BootPollingWithAcOffAndNoStoredTargetTemperaturesDoesNothing) {
-  this->ac_.setup();
-  ASSERT_EQ(this->ac_.state(), INIT);
-
-  this->run_boot_cycle(this->boot_off_cycle_responses_);
-  this->finish_boot_cycle_to_idle();
-  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
-  EXPECT_EQ(this->publish_count_, 1);
-}
-
-TEST_F(HlinkAcStateMachineTest, BootPollingWithAcOffAndRememberDisabledDoesNotApplyStoredTargetTemperatures) {
-  this->ac_.setup();
-  ASSERT_EQ(this->ac_.state(), INIT);
-
-  StoredTargetTemperatures stored_temps{};
-  stored_temps.cool_target_temperature = 24.0f;
-  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
-
-  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  EXPECT_EQ(this->ac_.state(), PUBLISH_UPDATE_IF_ANY);
   this->finish_boot_cycle_to_idle();
   EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
   EXPECT_EQ(this->publish_count_, 1);
@@ -422,41 +364,6 @@ TEST_F(HlinkAcStateMachineTest, BootPollingRetriesToInitOnIncompleteStatus) {
   this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // boot cycle retry
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
-}
-
-TEST_F(HlinkAcStateMachineTest, BootRetryWithFailedPowerReadDoesNotRestoreStoredTemperatures) {
-  this->ac_.set_remember_target_temperatures(true);
-  this->ac_.setup();
-  ASSERT_EQ(this->ac_.state(), INIT);
-
-  StoredTargetTemperatures stored_temps{};
-  stored_temps.cool_target_temperature = 24.0f;
-  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
-
-  // First boot cycle: the power read succeeds (off), the mode read fails, so the cycle is incomplete.
-  this->run_boot_cycle({"OK P=00 C=FFFF\r", "NG P=FFFF C=FFFF\r", "OK P=0016 C=FFE9\r",
-                        "OK P=0018 C=FFE7\r"});
-  EXPECT_EQ(this->ac_.state(), INIT);
-  EXPECT_EQ(this->publish_count_, 0);
-
-  // Retry: the power read fails again (stale off state is retained), the rest succeeds.
-  this->advance_for_next_send();
-  this->ac_.loop();  // INIT: start the boot cycle
-  this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
-  this->inject_response_and_step("NG P=FFFF C=FFFF\r");      // POWER_STATE: NG
-  this->send_poll_request_and_assert("MT P=0001 C=FFFE\r");  // MODE
-  this->inject_response_and_step("OK P=0010 C=FFEF\r");      // MODE: heat (stale off power -> OFF)
-  this->send_poll_request_and_assert("MT P=0003 C=FFFC\r");  // TARGET_TEMP
-  this->inject_response_and_step("OK P=0016 C=FFE9\r");      // TARGET_TEMP: 22°C
-  this->send_poll_request_and_assert("MT P=0100 C=FFFE\r");  // CURRENT_INDOOR_TEMP
-  this->inject_response_and_step("OK P=0018 C=FFE7\r");      // CURRENT_INDOOR_TEMP: 24°C
-
-  // The failed power read must prevent the cycle from completing, so no stored temperatures are restored.
-  EXPECT_EQ(this->ac_.state(), INIT);
-  EXPECT_EQ(this->publish_count_, 0);
-  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
 }
 
 TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureTargetTemperature) {
@@ -677,7 +584,7 @@ TEST_F(HlinkAcStateMachineTest, DoesNotRestoreWhenAcIsOnAtFirstPoll) {
   EXPECT_FLOAT_EQ(current_temps.cool_target_temperature.value(), 22.0f);
 }
 
-TEST_F(HlinkAcStateMachineTest, DoesNotReapplyStoredTargetTemperaturesOnSubsequentCycles) {
+TEST_F(HlinkAcStateMachineTest, ControlRestoresStoredTargetTemperatureWhenTurningOn) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
@@ -688,28 +595,185 @@ TEST_F(HlinkAcStateMachineTest, DoesNotReapplyStoredTargetTemperaturesOnSubseque
 
   this->run_boot_cycle(this->boot_off_cycle_responses_);
   this->finish_boot_cycle_to_idle();
-  this->ac_.loop();  // pending restore requests -> APPLY_REQUEST
-  ASSERT_EQ(this->ac_.state(), APPLY_REQUEST);
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");
-  this->inject_response_and_step(ACK_OK_FRAME);
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0018 C=FFE4\r");
-  this->inject_response_and_step(ACK_OK_FRAME);
-  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // status refresh cycle after the restore apply
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
 
-  this->run_polling_cycle({"OK P=00 C=FFFF\r",                    // POWER_STATE: off
-                           "OK P=0000 C=FFFF\r",                  // MODE: off
-                           "OK P=0016 C=FFE9\r",                  // TARGET_TEMP: 22°C (ignored when off)
-                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
-                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
-                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
-  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());           // no restore requests on subsequent cycles
-  auto restored_temps = this->ac_.stored_target_temperatures_for_test();
-  ASSERT_TRUE(restored_temps.cool_target_temperature.has_value());
-  EXPECT_FLOAT_EQ(restored_temps.cool_target_temperature.value(), 24.0f);
+  // The AC is turned on from Home Assistant without a target temperature, e.g. after a power cut.
+  this->ac_.control(this->ac_.make_call().set_mode(climate::ClimateMode::CLIMATE_MODE_COOL));
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");  // set MODE: cool
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0018 C=FFE4\r");  // TARGET_TEMP: 24°C (restored)
+  EXPECT_EQ(this->ac_.state(), ACK_APPLIED_REQUEST);
+
+  this->inject_response_and_step(ACK_OK_FRAME);
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // status refresh after the restore apply
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenCallIncludesTargetTemperature) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+
+  // The user turns the AC on and sets 22°C in the same call; the explicit value must win over the stored 24°C.
+  auto call = this->ac_.make_call();
+  call.set_mode(climate::ClimateMode::CLIMATE_MODE_COOL).set_target_temperature(22.0f);
+  this->ac_.control(call);
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");  // set MODE: cool
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0016 C=FFE6\r");  // TARGET_TEMP: 22°C
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // no restore request follows the explicit write
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenAcIsAlreadyOn) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_cool_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+
+  // Changing the mode while the AC is already running must not clobber its current temperature.
+  this->ac_.control(this->ac_.make_call().set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT));
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0010 C=FFEE\r");  // set MODE: heat
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // no restore request follows the mode write
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreOnAwayPresetTurnOn) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.heat_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+
+  // Entering away mode turns the AC on via the leave home sequence; it must not restore a regular temperature.
+  auto call = this->ac_.make_call();
+  call.set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT).set_preset(climate::ClimatePreset::CLIMATE_PRESET_AWAY);
+  this->ac_.control(call);
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0010 C=FFEE\r");  // set MODE: heat
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0010 C=FFEE\r");  // set MODE: heat (leave home sequence)
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0300,0040 C=FFBC\r");  // set LEAVE_HOME_STATUS_WRITE: enable
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on (leave home sequence)
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // no restore request in the leave home sequence
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlRestoresHeatCoolModeAutoEncodedTargetTemperature) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.set_reference_temperature(25);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.heat_cool_target_temperature = 24.0f;  // offset -1 from the reference temperature
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+
+  // The AC is turned on from Home Assistant in HEAT_COOL (auto) mode without a target temperature.
+  this->ac_.control(this->ac_.make_call().set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT_COOL));
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,8000 C=FF7E\r");  // set MODE: auto (HEAT_COOL)
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,FFFF C=FDFE\r");  // TARGET_TEMP: offset -1 (24°C)
+  EXPECT_EQ(this->ac_.state(), ACK_APPLIED_REQUEST);
+
+  this->inject_response_and_step(ACK_OK_FRAME);
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // status refresh after the restore apply
 }
 
 TEST_F(HlinkAcStateMachineTest, BootPollingTimedOutCycleRetriesToInit) {

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -659,20 +659,20 @@ TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenCallIncludesTargetTempe
   EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // no restore request follows the explicit write
 }
 
-TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenAcIsAlreadyOn) {
+TEST_F(HlinkAcStateMachineTest, ControlRestoresRememberedTemperatureWhenSwitchingModes) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
 
   StoredTargetTemperatures stored_temps{};
-  stored_temps.cool_target_temperature = 24.0f;
+  stored_temps.heat_target_temperature = 24.0f;
   this->ac_.set_stored_target_temperatures_for_test(stored_temps);
 
   this->run_boot_cycle(this->boot_cool_cycle_responses_);
   this->finish_boot_cycle_to_idle();
   EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
 
-  // Changing the mode while the AC is already running must not clobber its current temperature.
+  // Switching from cool to heat must restore the remembered heat target temperature.
   this->ac_.control(this->ac_.make_call().set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT));
   this->ac_.loop();  // pending requests -> APPLY_REQUEST
   EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
@@ -685,6 +685,43 @@ TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenAcIsAlreadyOn) {
   this->advance_for_next_send();
   this->ac_.loop();
   EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0010 C=FFEE\r");  // set MODE: heat
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0018 C=FFE4\r");  // TARGET_TEMP: 24°C (restored)
+  EXPECT_EQ(this->ac_.state(), ACK_APPLIED_REQUEST);
+
+  this->inject_response_and_step(ACK_OK_FRAME);
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // status refresh after the restore apply
+}
+
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotRestoreWhenAcAlreadyInRequestedMode) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_cool_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+
+  // Re-selecting the mode the AC is already running in must not clobber its current temperature.
+  this->ac_.control(this->ac_.make_call().set_mode(climate::ClimateMode::CLIMATE_MODE_COOL));
+  this->ac_.loop();  // pending requests -> APPLY_REQUEST
+  EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0000,01 C=FFFE\r");  // set POWER_STATE: on
+  this->inject_response_and_step(ACK_OK_FRAME);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");  // set MODE: cool
   this->inject_response_and_step(ACK_OK_FRAME);
 
   EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // no restore request follows the mode write

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -28,6 +28,35 @@ class HlinkAcStateMachineTest : public ::testing::Test {
     this->ac_.loop();
   }
 
+  void run_polling_cycle(const std::vector<std::string> &responses) {
+    ASSERT_EQ(responses.size(), this->ac_.status().polling_features.size());
+    const std::vector<std::string> requests = {
+        "MT P=0000 C=FFFF\r",  // POWER_STATE
+        "MT P=0001 C=FFFE\r",  // MODE
+        "MT P=0003 C=FFFC\r",  // TARGET_TEMP
+        "MT P=0100 C=FFFE\r",  // CURRENT_INDOOR_TEMP
+        "MT P=0002 C=FFFD\r",  // FAN_MODE
+        "MT P=0900 C=FFF6\r",  // MODEL_NAME
+        "MT P=0304 C=FFF8\r",  // LEAVE_HOME_STATUS_READ
+    };
+    for (size_t i = 0; i < responses.size(); i++) {
+      this->send_poll_request_and_assert(requests[i]);
+      this->inject_response_and_step(responses[i]);
+    }
+    EXPECT_EQ(this->ac_.state(), CAPTURE_TARGET_TEMPERATURE);
+    this->ac_.loop();
+    EXPECT_EQ(this->ac_.state(), IDLE);
+  }
+
+  const std::vector<std::string> cool_cycle_responses_ = {
+      "OK P=01 C=FFFE\r",                    // POWER_STATE: on
+      "OK P=0040 C=FFBF\r",                  // MODE: cool
+      "OK P=0016 C=FFE9\r",                  // TARGET_TEMP: 22°C
+      "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+      "OK P=01 C=FFFE\r",                    // FAN_MODE: high
+      "OK P=52414B2D3235504543 C=FDB5\r",    // MODEL_NAME: "RAK-25PEC"
+  };
+
   MockUARTComponent uart_;
   TestHlinkAc ac_;
   int publish_count_{0};
@@ -59,7 +88,9 @@ TEST_F(HlinkAcStateMachineTest, PollingCycleHappyPath) {
 
   this->send_poll_request_and_assert("MT P=0900 C=FFF6\r");            // MODEL_NAME
   this->inject_response_and_step("OK P=52414B2D3235504543 C=FDB5\r");  // MODEL_NAME: "RAK-25PEC"
+  EXPECT_EQ(this->ac_.state(), CAPTURE_TARGET_TEMPERATURE);
 
+  this->ac_.loop();
   EXPECT_EQ(this->ac_.state(), IDLE);
   EXPECT_EQ(this->ac_.mode, climate::ClimateMode::CLIMATE_MODE_COOL);
   EXPECT_FLOAT_EQ(this->ac_.target_temperature, 22.0f);
@@ -317,6 +348,110 @@ TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureWhenRememberDisabled) {
   EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
   EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
   EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingCapturesTargetTemperaturePerMode) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle(this->cool_cycle_responses_);
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 22.0f);
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingCapturesAutoModeTargetTemperature) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.set_reference_temperature(23);
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
+                           "OK P=8010 C=FF6F\r",                // MODE: heat auto
+                           "OK P=FFFF C=FE01\r",                // TARGET_TEMP: offset -1
+                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.heat_cool_target_temperature.has_value());
+  // Auto heating offset -1 is adjusted to -3, clamped to the auto range [20; 26].
+  EXPECT_FLOAT_EQ(stored_temps.heat_cool_target_temperature.value(), 20.0f);
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureWhenAcOff) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=00 C=FFFF\r",                  // POWER_STATE: off
+                           "OK P=0000 C=FFFF\r",                // MODE: off
+                           "OK P=0016 C=FFE9\r",                // TARGET_TEMP: 22°C (ignored when off)
+                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureWhenRememberDisabled) {
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle(this->cool_cycle_responses_);
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureAwayModeTargetTemperature) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.set_supported_climate_presets({climate::ClimatePreset::CLIMATE_PRESET_AWAY});
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
+                           "OK P=0010 C=FFEF\r",                // MODE: heat
+                           "OK P=000A C=FFF5\r",                // TARGET_TEMP: 10°C (away marker)
+                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r",  // MODEL_NAME: "RAK-25PEC"
+                           "OK P=80 C=FF7F\r"});                // LEAVE_HOME_STATUS_READ: enabled
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
+TEST_F(HlinkAcStateMachineTest, PollingSavesTargetTemperaturesOnlyOnChange) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle(this->cool_cycle_responses_);
+  EXPECT_EQ(this->ac_.save_settings_call_count_for_test(), 1);
+
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle(this->cool_cycle_responses_);
+  EXPECT_EQ(this->ac_.save_settings_call_count_for_test(), 1);
+
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
+                           "OK P=0040 C=FFBF\r",                // MODE: cool
+                           "OK P=0017 C=FFE8\r",                // TARGET_TEMP: 23°C
+                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+  EXPECT_EQ(this->ac_.save_settings_call_count_for_test(), 2);
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 23.0f);
 }
 
 TEST_F(HlinkAcStateMachineTest, PersistsTargetTemperaturesAcrossRestarts) {

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -387,7 +387,7 @@ TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureAwayModeTargetTemperature) 
                            "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
                            "OK P=01 C=FFFE\r",                  // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r",  // MODEL_NAME: "RAK-25PEC"
-                           "OK P=80 C=FF7F\r"});                // LEAVE_HOME_STATUS_READ: enabled
+                           "OK P=00000080 C=FF7F\r"});            // LEAVE_HOME_STATUS_READ: enabled
 
   auto stored_temps = this->ac_.stored_target_temperatures_for_test();
   EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -43,18 +43,59 @@ class HlinkAcStateMachineTest : public ::testing::Test {
       this->send_poll_request_and_assert(requests[i]);
       this->inject_response_and_step(responses[i]);
     }
-    EXPECT_EQ(this->ac_.state(), CAPTURE_TARGET_TEMPERATURE);
-    this->ac_.loop();
+    EXPECT_EQ(this->ac_.state(), PUBLISH_UPDATE_IF_ANY);
+    this->ac_.loop();  // CAPTURE_TARGET_TEMPERATURE
+    this->ac_.loop();  // IDLE
     EXPECT_EQ(this->ac_.state(), IDLE);
   }
 
+  // Sends the 4 minimal boot cycle requests and feeds them the given responses. The cycle completion
+  // lambda has already run, so the state is RESTORE_TARGET_TEMPERATURES on success or INIT on incomplete status.
+  void run_boot_cycle(const std::vector<std::string> &responses) {
+    ASSERT_EQ(responses.size(), 4U);
+    const std::vector<std::string> requests = {
+        "MT P=0000 C=FFFF\r",  // POWER_STATE
+        "MT P=0001 C=FFFE\r",  // MODE
+        "MT P=0003 C=FFFC\r",  // TARGET_TEMP
+        "MT P=0100 C=FFFE\r",  // CURRENT_INDOOR_TEMP
+    };
+    for (size_t i = 0; i < responses.size(); i++) {
+      this->send_poll_request_and_assert(requests[i]);
+      this->inject_response_and_step(responses[i]);
+    }
+  }
+
+  // Runs the boot cycle tail: RESTORE_TARGET_TEMPERATURES -> PUBLISH_UPDATE_IF_ANY -> CAPTURE_TARGET_TEMPERATURE ->
+  // IDLE. Must be called after a successful run_boot_cycle.
+  void finish_boot_cycle_to_idle() {
+    EXPECT_EQ(this->ac_.state(), RESTORE_TARGET_TEMPERATURES);
+    this->ac_.loop();  // RESTORE_TARGET_TEMPERATURES
+    this->ac_.loop();  // PUBLISH_UPDATE_IF_ANY
+    this->ac_.loop();  // CAPTURE_TARGET_TEMPERATURE
+    EXPECT_EQ(this->ac_.state(), IDLE);
+  }
+
+  const std::vector<std::string> boot_cool_cycle_responses_ = {
+      "OK P=01 C=FFFE\r",    // POWER_STATE: on
+      "OK P=0040 C=FFBF\r",  // MODE: cool
+      "OK P=0016 C=FFE9\r",  // TARGET_TEMP: 22°C
+      "OK P=0018 C=FFE7\r",  // CURRENT_INDOOR_TEMP: 24°C
+  };
+
+  const std::vector<std::string> boot_off_cycle_responses_ = {
+      "OK P=00 C=FFFF\r",    // POWER_STATE: off
+      "OK P=0000 C=FFFF\r",  // MODE: off
+      "OK P=0016 C=FFE9\r",  // TARGET_TEMP: 22°C (ignored when off)
+      "OK P=0018 C=FFE7\r",  // CURRENT_INDOOR_TEMP: 24°C
+  };
+
   const std::vector<std::string> cool_cycle_responses_ = {
-      "OK P=01 C=FFFE\r",                    // POWER_STATE: on
-      "OK P=0040 C=FFBF\r",                  // MODE: cool
-      "OK P=0016 C=FFE9\r",                  // TARGET_TEMP: 22°C
-      "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
-      "OK P=01 C=FFFE\r",                    // FAN_MODE: high
-      "OK P=52414B2D3235504543 C=FDB5\r",    // MODEL_NAME: "RAK-25PEC"
+      "OK P=01 C=FFFE\r",                  // POWER_STATE: on
+      "OK P=0040 C=FFBF\r",                // MODE: cool
+      "OK P=0016 C=FFE9\r",                // TARGET_TEMP: 22°C
+      "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+      "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+      "OK P=52414B2D3235504543 C=FDB5\r",  // MODEL_NAME: "RAK-25PEC"
   };
 
   MockUARTComponent uart_;
@@ -88,8 +129,10 @@ TEST_F(HlinkAcStateMachineTest, PollingCycleHappyPath) {
 
   this->send_poll_request_and_assert("MT P=0900 C=FFF6\r");            // MODEL_NAME
   this->inject_response_and_step("OK P=52414B2D3235504543 C=FDB5\r");  // MODEL_NAME: "RAK-25PEC"
-  EXPECT_EQ(this->ac_.state(), CAPTURE_TARGET_TEMPERATURE);
+  EXPECT_EQ(this->ac_.state(), PUBLISH_UPDATE_IF_ANY);
 
+  this->ac_.loop();
+  EXPECT_EQ(this->ac_.state(), CAPTURE_TARGET_TEMPERATURE);
   this->ac_.loop();
   EXPECT_EQ(this->ac_.state(), IDLE);
   EXPECT_EQ(this->ac_.mode, climate::ClimateMode::CLIMATE_MODE_COOL);
@@ -179,7 +222,7 @@ TEST_F(HlinkAcStateMachineTest, HandlesLowPriorityRequestFromIdle) {
                                               });
 
   this->ac_.loop();
-  EXPECT_EQ(this->ac_.state(), REQUEST_LOW_PRIORITY_FEATURE);
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
 
   this->advance_for_next_send();
   this->ac_.loop();
@@ -200,7 +243,7 @@ TEST_F(HlinkAcStateMachineTest, InvokesTimeoutCallbackAndResetsState) {
                                               nullptr, nullptr, [&]() { timeout_called = true; });
 
   this->ac_.loop();
-  ASSERT_EQ(this->ac_.state(), REQUEST_LOW_PRIORITY_FEATURE);
+  ASSERT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
 
   this->advance_for_next_send();
   this->ac_.loop();
@@ -208,7 +251,7 @@ TEST_F(HlinkAcStateMachineTest, InvokesTimeoutCallbackAndResetsState) {
   EXPECT_EQ(this->uart_.take_tx_as_string(),
             "MT P=0900 C=FFF6\r");  // request MODEL_NAME
 
-  this->ac_.advance_current_time_ms_for_test(301);
+  this->ac_.advance_current_time_ms_for_test(501);
   this->ac_.loop();
 
   EXPECT_TRUE(timeout_called);
@@ -217,21 +260,18 @@ TEST_F(HlinkAcStateMachineTest, InvokesTimeoutCallbackAndResetsState) {
   EXPECT_EQ(this->publish_count_, 0);
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitSendsPowerStateRequestAndTransitionsToIdle) {
+TEST_F(HlinkAcStateMachineTest, BootPollingCycleSendsOnlyMinimalRequestsAndTransitionsToIdle) {
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
 
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
-
-  this->inject_response_and_step("OK P=01 C=FFFE\r");
-  EXPECT_EQ(this->ac_.state(), IDLE);
-  EXPECT_EQ(this->publish_count_, 0);
+  this->run_boot_cycle(this->boot_cool_cycle_responses_);
+  EXPECT_EQ(this->ac_.state(), RESTORE_TARGET_TEMPERATURES);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+  EXPECT_EQ(this->publish_count_, 1);
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAppliesStoredTargetTemperatures) {
+TEST_F(HlinkAcStateMachineTest, RestoresTargetTemperaturesAfterFirstSuccessfulBootPoll) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
@@ -240,12 +280,10 @@ TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAppliesStoredTargetTemperature
   stored_temps.cool_target_temperature = 24.0f;
   this->ac_.set_stored_target_temperatures_for_test(stored_temps);
 
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
 
-  this->inject_response_and_step("OK P=00 C=FFFF\r");
+  this->ac_.loop();  // pending restore requests -> APPLY_REQUEST
   EXPECT_EQ(this->ac_.state(), APPLY_REQUEST);
 
   this->advance_for_next_send();
@@ -263,25 +301,20 @@ TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAppliesStoredTargetTemperature
 
   this->inject_response_and_step(ACK_OK_FRAME);
   EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);
-  EXPECT_EQ(this->publish_count_, 0);
+  EXPECT_EQ(this->publish_count_, 1);
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndNoStoredTargetTemperaturesDoesNothing) {
+TEST_F(HlinkAcStateMachineTest, BootPollingWithAcOffAndNoStoredTargetTemperaturesDoesNothing) {
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
 
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
-
-  this->inject_response_and_step("OK P=00 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), IDLE);
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
   EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
-  EXPECT_EQ(this->publish_count_, 0);
+  EXPECT_EQ(this->publish_count_, 1);
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndRememberDisabledDoesNotApplyStoredTargetTemperatures) {
+TEST_F(HlinkAcStateMachineTest, BootPollingWithAcOffAndRememberDisabledDoesNotApplyStoredTargetTemperatures) {
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
 
@@ -289,15 +322,25 @@ TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndRememberDisabledDoesNotAppl
   stored_temps.cool_target_temperature = 24.0f;
   this->ac_.set_stored_target_temperatures_for_test(stored_temps);
 
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
+  EXPECT_EQ(this->publish_count_, 1);
+}
+
+TEST_F(HlinkAcStateMachineTest, BootPollingRetriesToInitOnIncompleteStatus) {
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  this->run_boot_cycle({"OK P=01 C=FFFE\r", "NG P=FFFF C=FFFF\r", "OK P=0016 C=FFE9\r",
+                        "OK P=0018 C=FFE7\r"});  // MODE: NG, so the minimal status is incomplete
+  EXPECT_EQ(this->ac_.state(), INIT);
+  EXPECT_EQ(this->publish_count_, 0);
+
   this->advance_for_next_send();
   this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // boot cycle retry
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
-
-  this->inject_response_and_step("OK P=00 C=FFFF\r");
-  EXPECT_EQ(this->ac_.state(), IDLE);
-  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());
-  EXPECT_EQ(this->publish_count_, 0);
 }
 
 TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureTargetTemperature) {
@@ -333,11 +376,11 @@ TEST_F(HlinkAcStateMachineTest, PollingCapturesAutoModeTargetTemperature) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.set_reference_temperature(23);
   this->ac_.request_status_update_for_test();
-  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
-                           "OK P=8010 C=FF6F\r",                // MODE: heat auto
-                           "OK P=FFFF C=FE01\r",                // TARGET_TEMP: offset -1
-                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
-                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                    // POWER_STATE: on
+                           "OK P=8010 C=FF6F\r",                  // MODE: heat auto
+                           "OK P=FFFF C=FE01\r",                  // TARGET_TEMP: offset -1
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
 
   auto stored_temps = this->ac_.stored_target_temperatures_for_test();
@@ -352,11 +395,11 @@ TEST_F(HlinkAcStateMachineTest, PollingCapturesAutoModeTargetTemperature) {
 TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureWhenAcOff) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.request_status_update_for_test();
-  this->run_polling_cycle({"OK P=00 C=FFFF\r",                  // POWER_STATE: off
-                           "OK P=0000 C=FFFF\r",                // MODE: off
-                           "OK P=0016 C=FFE9\r",                // TARGET_TEMP: 22°C (ignored when off)
-                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
-                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+  this->run_polling_cycle({"OK P=00 C=FFFF\r",                    // POWER_STATE: off
+                           "OK P=0000 C=FFFF\r",                  // MODE: off
+                           "OK P=0016 C=FFE9\r",                  // TARGET_TEMP: 22°C (ignored when off)
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
 
   auto stored_temps = this->ac_.stored_target_temperatures_for_test();
@@ -387,7 +430,7 @@ TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureAwayModeTargetTemperature) 
                            "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
                            "OK P=01 C=FFFE\r",                  // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r",  // MODEL_NAME: "RAK-25PEC"
-                           "OK P=00000080 C=FF7F\r"});            // LEAVE_HOME_STATUS_READ: enabled
+                           "OK P=00000080 C=FF7F\r"});          // LEAVE_HOME_STATUS_READ: enabled
 
   auto stored_temps = this->ac_.stored_target_temperatures_for_test();
   EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
@@ -407,11 +450,11 @@ TEST_F(HlinkAcStateMachineTest, PollingSavesTargetTemperaturesOnlyOnChange) {
   EXPECT_EQ(this->ac_.save_settings_call_count_for_test(), 1);
 
   this->ac_.request_status_update_for_test();
-  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
-                           "OK P=0040 C=FFBF\r",                // MODE: cool
-                           "OK P=0017 C=FFE8\r",                // TARGET_TEMP: 23°C
-                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
-                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                    // POWER_STATE: on
+                           "OK P=0040 C=FFBF\r",                  // MODE: cool
+                           "OK P=0017 C=FFE8\r",                  // TARGET_TEMP: 23°C
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
   EXPECT_EQ(this->ac_.save_settings_call_count_for_test(), 2);
 
@@ -424,18 +467,19 @@ TEST_F(HlinkAcStateMachineTest, PersistsTargetTemperaturesAcrossRestarts) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
-  this->advance_for_next_send();
-  this->ac_.loop();
-  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // INIT: POWER_STATE
-  this->inject_response_and_step("OK P=01 C=FFFE\r");                // POWER_STATE: on
-  ASSERT_EQ(this->ac_.state(), IDLE);
+  this->run_boot_cycle({"OK P=01 C=FFFE\r",      // POWER_STATE: on
+                        "OK P=0010 C=FFEF\r",    // MODE: heat
+                        "OK P=001A C=FFE5\r",    // TARGET_TEMP: 26°C
+                        "OK P=0018 C=FFE7\r"});  // CURRENT_INDOOR_TEMP: 24°C
+  this->finish_boot_cycle_to_idle();
+  EXPECT_EQ(this->publish_count_, 1);
 
   this->ac_.request_status_update_for_test();
-  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
-                           "OK P=0010 C=FFEF\r",                // MODE: heat
-                           "OK P=001A C=FFE5\r",                // TARGET_TEMP: 26°C
-                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
-                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                    // POWER_STATE: on
+                           "OK P=0010 C=FFEF\r",                  // MODE: heat
+                           "OK P=001A C=FFE5\r",                  // TARGET_TEMP: 26°C
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
                            "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
 
   TestHlinkAc restarted_ac;
@@ -451,7 +495,91 @@ TEST_F(HlinkAcStateMachineTest, PersistsTargetTemperaturesAcrossRestarts) {
   EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
 }
 
-TEST_F(HlinkAcStateMachineTest, SetupInitTimeoutResetsToIdle) {
+TEST_F(HlinkAcStateMachineTest, RestoresHeatTargetTemperatureOutsideAutoRange) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+  this->run_boot_cycle({"OK P=01 C=FFFE\r",      // POWER_STATE: on
+                        "OK P=0010 C=FFEF\r",    // MODE: heat
+                        "OK P=001E C=FFE1\r",    // TARGET_TEMP: 30°C
+                        "OK P=0018 C=FFE7\r"});  // CURRENT_INDOOR_TEMP: 24°C
+  this->finish_boot_cycle_to_idle();
+  EXPECT_EQ(this->publish_count_, 1);
+
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                    // POWER_STATE: on
+                           "OK P=0010 C=FFEF\r",                  // MODE: heat
+                           "OK P=001E C=FFE1\r",                  // TARGET_TEMP: 30°C
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+
+  TestHlinkAc restarted_ac;
+  restarted_ac.set_uart_parent_for_test(&this->uart_);
+  restarted_ac.set_current_time_ms_for_test(0);
+  restarted_ac.setup();
+
+  auto stored_temps = restarted_ac.stored_target_temperatures_for_test();
+  ASSERT_TRUE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(stored_temps.heat_target_temperature.value(), 30.0f);
+}
+
+TEST_F(HlinkAcStateMachineTest, DoesNotRestoreWhenAcIsOnAtFirstPoll) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_cool_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());  // no restore ST requests when the AC is on
+  EXPECT_EQ(this->publish_count_, 1);
+
+  // The polled target temperature was captured instead of restoring the stored one.
+  auto current_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(current_temps.cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(current_temps.cool_target_temperature.value(), 22.0f);
+}
+
+TEST_F(HlinkAcStateMachineTest, DoesNotReapplyStoredTargetTemperaturesOnSubsequentCycles) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.setup();
+  ASSERT_EQ(this->ac_.state(), INIT);
+
+  StoredTargetTemperatures stored_temps{};
+  stored_temps.cool_target_temperature = 24.0f;
+  this->ac_.set_stored_target_temperatures_for_test(stored_temps);
+
+  this->run_boot_cycle(this->boot_off_cycle_responses_);
+  this->finish_boot_cycle_to_idle();
+  this->ac_.loop();  // pending restore requests -> APPLY_REQUEST
+  ASSERT_EQ(this->ac_.state(), APPLY_REQUEST);
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0001,0040 C=FFBE\r");
+  this->inject_response_and_step(ACK_OK_FRAME);
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "ST P=0003,0018 C=FFE4\r");
+  this->inject_response_and_step(ACK_OK_FRAME);
+  EXPECT_EQ(this->ac_.state(), REQUEST_NEXT_STATUS_FEATURE);  // status refresh cycle after the restore apply
+
+  this->run_polling_cycle({"OK P=00 C=FFFF\r",                    // POWER_STATE: off
+                           "OK P=0000 C=FFFF\r",                  // MODE: off
+                           "OK P=0016 C=FFE9\r",                  // TARGET_TEMP: 22°C (ignored when off)
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+  EXPECT_TRUE(this->uart_.take_tx_as_string().empty());           // no restore requests on subsequent cycles
+  auto restored_temps = this->ac_.stored_target_temperatures_for_test();
+  ASSERT_TRUE(restored_temps.cool_target_temperature.has_value());
+  EXPECT_FLOAT_EQ(restored_temps.cool_target_temperature.value(), 24.0f);
+}
+
+TEST_F(HlinkAcStateMachineTest, BootPollingTimedOutCycleRetriesToInit) {
   this->ac_.setup();
   ASSERT_EQ(this->ac_.state(), INIT);
 
@@ -460,12 +588,17 @@ TEST_F(HlinkAcStateMachineTest, SetupInitTimeoutResetsToIdle) {
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
 
-  this->ac_.advance_current_time_ms_for_test(301);
+  this->ac_.advance_current_time_ms_for_test(2001);
   this->ac_.loop();
 
-  EXPECT_EQ(this->ac_.state(), IDLE);
+  EXPECT_EQ(this->ac_.state(), INIT);  // boot cycle retries without backoff
   EXPECT_EQ(this->ac_.status().current_request, nullptr);
   EXPECT_EQ(this->publish_count_, 0);
+
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
+  EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
 }
 
 }  // namespace esphome::hlink_ac::testing

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -446,6 +446,23 @@ TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureAwayModeTargetTemperature) 
   EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
 }
 
+TEST_F(HlinkAcStateMachineTest, PollingDoesNotCaptureAwayModeTargetTemperatureWhenLeaveHomeStatusUnknown) {
+  this->ac_.set_remember_target_temperatures(true);
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                    // POWER_STATE: on
+                           "OK P=0010 C=FFEF\r",                  // MODE: heat
+                           "OK P=000A C=FFF5\r",                  // TARGET_TEMP: 10°C (away marker)
+                           "OK P=0018 C=FFE7\r",                  // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                    // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
+
+  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
+  EXPECT_FALSE(stored_temps.cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
+  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
+}
+
 TEST_F(HlinkAcStateMachineTest, PollingSavesTargetTemperaturesOnlyOnChange) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.request_status_update_for_test();

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -300,43 +300,9 @@ TEST_F(HlinkAcStateMachineTest, SetupInitWithAcOffAndRememberDisabledDoesNotAppl
   EXPECT_EQ(this->publish_count_, 0);
 }
 
-TEST_F(HlinkAcStateMachineTest, ControlCapturesTargetTemperaturePerMode) {
+TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureTargetTemperature) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.set_reference_temperature(23);
-  this->ac_.setup();
-
-  auto call = this->ac_.make_call();
-  call.set_mode(climate::ClimateMode::CLIMATE_MODE_COOL).set_target_temperature(24.0f);
-  this->ac_.control(call);
-
-  auto stored_temps = this->ac_.stored_target_temperatures_for_test();
-  ASSERT_TRUE(stored_temps.cool_target_temperature.has_value());
-  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
-  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
-  EXPECT_FALSE(stored_temps.heat_cool_target_temperature.has_value());
-  EXPECT_FALSE(stored_temps.dry_target_temperature.has_value());
-
-  // Auto-mode temperature is clamped and stored in the auto range.
-  auto auto_call = this->ac_.make_call();
-  auto_call.set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT_COOL).set_target_temperature(28.0f);
-  this->ac_.control(auto_call);
-
-  stored_temps = this->ac_.stored_target_temperatures_for_test();
-  ASSERT_TRUE(stored_temps.heat_cool_target_temperature.has_value());
-  EXPECT_FLOAT_EQ(stored_temps.heat_cool_target_temperature.value(), 26.0f);
-  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
-
-  // OFF mode does not capture a target temperature.
-  auto off_call = this->ac_.make_call();
-  off_call.set_mode(climate::ClimateMode::CLIMATE_MODE_OFF).set_target_temperature(22.0f);
-  this->ac_.control(off_call);
-
-  stored_temps = this->ac_.stored_target_temperatures_for_test();
-  EXPECT_FLOAT_EQ(stored_temps.cool_target_temperature.value(), 24.0f);
-  EXPECT_FALSE(stored_temps.heat_target_temperature.has_value());
-}
-
-TEST_F(HlinkAcStateMachineTest, ControlDoesNotCaptureWhenRememberDisabled) {
   this->ac_.setup();
 
   auto call = this->ac_.make_call();
@@ -457,9 +423,20 @@ TEST_F(HlinkAcStateMachineTest, PollingSavesTargetTemperaturesOnlyOnChange) {
 TEST_F(HlinkAcStateMachineTest, PersistsTargetTemperaturesAcrossRestarts) {
   this->ac_.set_remember_target_temperatures(true);
   this->ac_.setup();
-  auto call = this->ac_.make_call();
-  call.set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT).set_target_temperature(26.0f);
-  this->ac_.control(call);
+  ASSERT_EQ(this->ac_.state(), INIT);
+  this->advance_for_next_send();
+  this->ac_.loop();
+  EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // INIT: POWER_STATE
+  this->inject_response_and_step("OK P=01 C=FFFE\r");                // POWER_STATE: on
+  ASSERT_EQ(this->ac_.state(), IDLE);
+
+  this->ac_.request_status_update_for_test();
+  this->run_polling_cycle({"OK P=01 C=FFFE\r",                  // POWER_STATE: on
+                           "OK P=0010 C=FFEF\r",                // MODE: heat
+                           "OK P=001A C=FFE5\r",                // TARGET_TEMP: 26°C
+                           "OK P=0018 C=FFE7\r",                // CURRENT_INDOOR_TEMP: 24°C
+                           "OK P=01 C=FFFE\r",                  // FAN_MODE: high
+                           "OK P=52414B2D3235504543 C=FDB5\r"});  // MODEL_NAME: "RAK-25PEC"
 
   TestHlinkAc restarted_ac;
   restarted_ac.set_uart_parent_for_test(&this->uart_);

--- a/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
+++ b/tests/components/hlink_ac/hlink_ac_state_machine_test.cpp
@@ -59,7 +59,13 @@ class HlinkAcStateMachineTest : public ::testing::Test {
         "MT P=0003 C=FFFC\r",  // TARGET_TEMP
         "MT P=0100 C=FFFE\r",  // CURRENT_INDOOR_TEMP
     };
-    for (size_t i = 0; i < responses.size(); i++) {
+    this->advance_for_next_send();
+    this->ac_.loop();  // INIT: start the boot cycle
+    this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the first request
+    EXPECT_EQ(this->uart_.take_tx_as_string(), requests[0]);
+    EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
+    this->inject_response_and_step(responses[0]);
+    for (size_t i = 1; i < responses.size(); i++) {
       this->send_poll_request_and_assert(requests[i]);
       this->inject_response_and_step(responses[i]);
     }
@@ -338,7 +344,8 @@ TEST_F(HlinkAcStateMachineTest, BootPollingRetriesToInitOnIncompleteStatus) {
   EXPECT_EQ(this->publish_count_, 0);
 
   this->advance_for_next_send();
-  this->ac_.loop();
+  this->ac_.loop();  // INIT: start the boot cycle
+  this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");  // boot cycle retry
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
 }
@@ -584,7 +591,8 @@ TEST_F(HlinkAcStateMachineTest, BootPollingTimedOutCycleRetriesToInit) {
   ASSERT_EQ(this->ac_.state(), INIT);
 
   this->advance_for_next_send();
-  this->ac_.loop();
+  this->ac_.loop();  // INIT: start the boot cycle
+  this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the first request
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
 
@@ -596,7 +604,8 @@ TEST_F(HlinkAcStateMachineTest, BootPollingTimedOutCycleRetriesToInit) {
   EXPECT_EQ(this->publish_count_, 0);
 
   this->advance_for_next_send();
-  this->ac_.loop();
+  this->ac_.loop();  // INIT: start the boot cycle
+  this->ac_.loop();  // REQUEST_NEXT_STATUS_FEATURE: send the retry request
   EXPECT_EQ(this->uart_.take_tx_as_string(), "MT P=0000 C=FFFF\r");
   EXPECT_EQ(this->ac_.state(), READ_FEATURE_RESPONSE);
 }


### PR DESCRIPTION
## What

Remember the last set target temperature per climate mode and restore it when the AC is turned on or switched to a mode.

- Added `remember_target_temperatures` option to the climate platform. When enabled, the target temperature of heat, cool, dry and heat_cool modes is captured from status polling and persisted in NVS.
- When the AC is turned on, or switched from one mode to another, from Home Assistant without an explicit target temperature in the same call, the stored target temperature for the requested mode is written back (ST request). It is not restored when re-selecting the mode the AC is already running in, for calls that include a target temperature, or for leave-home (away) preset sequences. HEAT_COOL (auto) targets are encoded as offsets around the reference temperature.

## How

- Status polling reworked into self-contained polling cycles: each cycle defines the feature list, an optional completion hook deciding the next state, and the target state on timeout (`PollCycleDefinition` / `PollingCycle`).
- New state `POLL_DONE` runs the cycle completion hook; the boot cycle polls 4 minimal features and retries until a minimal status is received (no backoff).
- Low-priority requests (debug discovery) are now modeled as single-feature polling cycles, which removes the `REQUEST_LOW_PRIORITY_FEATURE` state and the `requested_feature_index == -1` sentinel.
- All status features are built by `make_*_request_()` factories so arbitrary cycles can compose them.
- Captured targets are shared through `stored_target_temperature_for_()`; the turn-on/switch restore writes them via `enqueue_remembered_target_temperature_()` from `control()`.
- Fixed restoration of heat target temperatures to use the protocol range (10..32) instead of the auto-mode range.

## Tests

Unit tests cover polling cycles happy path, boot cycle minimal polling + capture on first successful poll, boot retry on timeout and on incomplete status, per-mode capture (including leave-home and auto-mode edge cases), and restore from `control()` (stored value written back when turning on, stored value written back when switching modes while running, no restore when re-selecting the current mode, explicit temperature in the call wins, no restore for away sequences, auto-mode offset encoding). All 76 tests pass; all three compile targets (`espidf`, `arduino`, `libretiny`) build.
