### PR TITLE
Bump ESPHome to 2026.8.2

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -33,5 +33,5 @@ jobs:
           docker run --rm \
             -v "${{ github.workspace }}/build":/config \
             -v "${{ github.workspace }}/components":/components \
-            esphome/esphome:2026.7.2 \
+            esphome/esphome:2026.8.2 \
             compile ${{ matrix.config }}

--- a/build/clean
+++ b/build/clean
@@ -3,6 +3,6 @@
 docker run --rm \
   -v "$(pwd)":/config \
   -v "$(pwd)/../components":/components \
-  -it esphome/esphome:2026.7.2 \
+  -it esphome/esphome:2026.8.2 \
   clean \
   *.yml

--- a/build/compile
+++ b/build/compile
@@ -8,11 +8,11 @@ if [ -z "$CONFIG_FILE" ]; then
   CONFIG_FILE="*.yml"
 fi
 
-docker pull esphome/esphome:2026.7.2
+docker pull esphome/esphome:2026.8.2
 
 docker run --rm \
   -v "$(pwd)":/config \
   -v "$(pwd)/../components":/components \
-  -it esphome/esphome:2026.7.2 \
+  -it esphome/esphome:2026.8.2 \
   compile \
   $CONFIG_FILE

--- a/build/test-runner/Dockerfile
+++ b/build/test-runner/Dockerfile
@@ -3,10 +3,10 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git build-essential && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir esphome==2026.7.2 platformio
-RUN pio platform install "native"
+RUN pip install --no-cache-dir esphome==2026.8.2 platformio
+RUN pio pkg install --global --platform "native"
 
-RUN git clone --depth 1 --branch 2026.7.2 \
+RUN git clone --depth 1 --branch 2026.8.2 \
     https://github.com/esphome/esphome.git /esphome
 RUN cd /esphome && pip install -e . --quiet --no-deps 2>&1 | tail -1
 


### PR DESCRIPTION
## Summary
- bump ESPHome from 2026.7.2 to the latest stable 2026.8.2 release
- update compile, clean, CI, and C++ test runner tooling
- replace the deprecated PlatformIO platform install command

## Validation
- `cd build && ./test all` — 76 tests passed
- compiled all six `build/*.yml` configurations with ESPHome 2026.8.2
- compile output contained no warnings or deprecation diagnostics
- test image build contained no deprecation diagnostics